### PR TITLE
16 refactor all console outputs to use the new coriandercore consoleoutput class

### DIFF
--- a/CorianderCore/core/Console/CommandHandler.php
+++ b/CorianderCore/core/Console/CommandHandler.php
@@ -24,6 +24,7 @@ class CommandHandler
      */
     public function handle(string $command, array $args)
     {
+        ConsoleOutput::hr();
         // Check if the command contains a colon (e.g., make:view)
         $splitCommand = explode(':', $command);
 
@@ -34,13 +35,15 @@ class CommandHandler
         // If 'help' is requested or no command is provided, display the list of commands
         if ($mainCommand === 'help' || !$mainCommand) {
             $this->listCommands();
+            ConsoleOutput::hr();
             return;
         }
 
         // Check if the main command exists
         if (!isset($this->commands[$mainCommand])) {
-            echo "Unknown command: {$mainCommand}" . PHP_EOL;
+            ConsoleOutput::print("&4[Error]&7 Unknown command: {$mainCommand}\n");
             $this->listCommands();
+            ConsoleOutput::hr();
             return;
         }
 
@@ -66,6 +69,7 @@ class CommandHandler
 
         // Execute the main command with the provided arguments (subcommand included)
         $commandInstance->execute($args);
+        ConsoleOutput::hr();
     }
 
     /**
@@ -73,14 +77,14 @@ class CommandHandler
      */
     protected function listCommands()
     {
-        echo "Available commands:" . PHP_EOL;
+        ConsoleOutput::print("Available commands:");
 
         // Always include 'help' as an available command
-        echo "  - help" . PHP_EOL;
+        ConsoleOutput::print("| - help");
 
         // List all commands from the $commands array
         foreach ($this->commands as $cmd => $class) {
-            echo "  - {$cmd}" . PHP_EOL;
+            ConsoleOutput::print("| - {$cmd}");
         }
     }
 }

--- a/CorianderCore/core/Console/Commands/Controller/MakeController.php
+++ b/CorianderCore/core/Console/Commands/Controller/MakeController.php
@@ -2,6 +2,8 @@
 
 namespace CorianderCore\Console\Commands\Controller;
 
+use CorianderCore\Console\ConsoleOutput;
+
 /**
  * The MakeController class is responsible for generating new controller files
  * based on predefined templates. It ensures that controllers are created in
@@ -41,7 +43,7 @@ class MakeController
     {
         // Ensure a controller name is provided.
         if (empty($args)) {
-            echo "Error: Please specify a controller name." . PHP_EOL;
+            ConsoleOutput::print("&4[Error]&7 Please specify a controller name.");
             return;
         }
 
@@ -64,16 +66,16 @@ class MakeController
 
         // Check if the controller already exists.
         if ($this->controllerExists($controllerPath)) {
-            echo "Error: Controller '{$controllerName}' already exists." . PHP_EOL;
+            ConsoleOutput::print("&4[Error]&7 Controller '{$controllerName}' already exists.");
             return;
         }
 
         // Create the controller file using the template.
         try {
             $this->createFileFromTemplate('Controller.php', $controllerPath, $controllerName, $kebabCaseName);
-            echo "Controller '{$controllerName}' created successfully at '{$controllerPath}'." . PHP_EOL;
+            ConsoleOutput::print("&2[Success]&7 Controller '{$controllerName}' created successfully at '{$controllerPath}'. ");
         } catch (\Exception $e) {
-            echo "Error: Failed to create controller '{$controllerName}'. " . $e->getMessage() . PHP_EOL;
+            ConsoleOutput::print("&4[Error]&7 Failed to create controller '{$controllerName}'. " . $e->getMessage());
         }
     }
 

--- a/CorianderCore/core/Console/Commands/Database/MakeDatabase.php
+++ b/CorianderCore/core/Console/Commands/Database/MakeDatabase.php
@@ -25,7 +25,6 @@ class MakeDatabase
         $iniPath = php_ini_loaded_file();  // Get the currently loaded php.ini file
 
         if (!$mysqlAvailable) {
-            ConsoleOutput::hr();
             ConsoleOutput::print("&e| [Warning]&r&7 &uMySQL PDO driver is not available&r&7.");
             ConsoleOutput::print("&e| &7You will not be able to create a MySQL database.\n&e|");
             ConsoleOutput::print("&e| &7To install the MySQL PDO driver, refer to the following:");
@@ -59,7 +58,6 @@ class MakeDatabase
                 case '0':
                 case '':
                     ConsoleOutput::print("Exiting the database creation process.");
-                    ConsoleOutput::hr();
                     return;  // Exit the loop and terminate the script
                 case '1':
                     if ($mysqlAvailable) {
@@ -67,7 +65,7 @@ class MakeDatabase
                         $mysqlMaker->execute();
                         return;  // Exit the loop after successful MySQL execution
                     } else {
-                        ConsoleOutput::print("&l&4[Error]&r&7 MySQL is not available on this system.");
+                        ConsoleOutput::print("&l&4[Error]&7 MySQL is not available on this system.");
                     }
                     break;
                 case '2':
@@ -75,8 +73,7 @@ class MakeDatabase
                     $sqliteMaker->execute();
                     return;  // Exit the loop after successful SQLite execution
                 default:
-                    ConsoleOutput::print("&4[Error]&r&7 Invalid choice. Please enter &l0&r&7 to exit, &l1&r&7 for MySQL, or &l2&r&7 for SQLite.");
-                    ConsoleOutput::hr();
+                    ConsoleOutput::print("&4[Error]&7 Invalid choice. Please enter &l0&r&7 to exit, &l1&r&7 for MySQL, or &l2&r&7 for SQLite.");
                     break;
             }
         } while (true);  // Continue the loop until a valid choice is made or the user exits

--- a/CorianderCore/core/Console/Commands/Database/MySQL/MakeMySQL.php
+++ b/CorianderCore/core/Console/Commands/Database/MySQL/MakeMySQL.php
@@ -2,6 +2,7 @@
 
 namespace CorianderCore\Console\Commands\Database\MySQL;
 
+use CorianderCore\Console\ConsoleOutput;
 use \PDO;
 use \PDOException;
 
@@ -38,16 +39,19 @@ class MakeMySQL
     public function execute()
     {
         // Ask the user for MySQL connection details
-        echo "Enter MySQL host: ";
+        ConsoleOutput::print("Enter MySQL host:\n");
         $dbHost = trim(fgets(STDIN));
 
-        echo "Enter MySQL database name: ";
+        ConsoleOutput::hr();
+        ConsoleOutput::print("Enter MySQL database name:\n");
         $dbName = trim(fgets(STDIN));
 
-        echo "Enter MySQL user: ";
+        ConsoleOutput::hr();
+        ConsoleOutput::print("Enter MySQL user:\n");
         $dbUser = trim(fgets(STDIN));
 
-        echo "Enter MySQL password: ";
+        ConsoleOutput::hr();
+        ConsoleOutput::print("Enter MySQL password:\n");
         $dbPassword = trim(fgets(STDIN));
 
         // Test the MySQL connection
@@ -55,12 +59,15 @@ class MakeMySQL
             $dsn = "mysql:host=$dbHost;dbname=$dbName";
             $pdo = new PDO($dsn, $dbUser, $dbPassword);
             $pdo->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_EXCEPTION);
-            echo "Connection successful! Proceeding with configuration...\n";
+            ConsoleOutput::hr();
+            ConsoleOutput::print("&2[Success]&r&7 Connection successful! Proceeding with configuration...");
         } catch (PDOException $e) {
-            echo "Connection failed: " . $e->getMessage() . "\n";
-            echo "Do you want to proceed anyway? (y/n): ";
+            ConsoleOutput::hr();
+            ConsoleOutput::print("&4[Error]&7 Connection failed: " . $e->getMessage());
+            ConsoleOutput::print("Do you want to proceed anyway? (y/n):\n");
             $confirmation = strtolower(trim(fgets(STDIN)));
             if ($confirmation !== 'y') {
+                ConsoleOutput::print("&e[Warning]&7 Database configuration file not created.");
                 return;
             }
         }
@@ -91,7 +98,7 @@ class MakeMySQL
 
         // Save the generated configuration file
         $this->saveConfig($content);
-        echo "MySQL configuration generated successfully.\n";
+        ConsoleOutput::print("&2[Success]&r&7 MySQL configuration generated successfully.");
     }
 
     /**

--- a/CorianderCore/core/Console/Commands/Database/SQLite/MakeSQLite.php
+++ b/CorianderCore/core/Console/Commands/Database/SQLite/MakeSQLite.php
@@ -2,6 +2,8 @@
 
 namespace CorianderCore\Console\Commands\Database\SQLite;
 
+use CorianderCore\Console\ConsoleOutput;
+
 /**
  * The MakeSQLite class is responsible for generating and setting up SQLite database configurations.
  */
@@ -40,12 +42,15 @@ class MakeSQLite
     public function execute()
     {
         // Ask the user for the SQLite database name
-        echo "Enter SQLite database name (without extension): ";
+        ConsoleOutput::print("Enter SQLite database name (without extension):\n");
         $dbName = trim(fgets(STDIN));
+        ConsoleOutput::hr();
 
         // Generate SQLite configuration and database files
         $this->generateConfig($dbName);
         $this->createDatabaseFiles($dbName);
+        ConsoleOutput::hr();
+        ConsoleOutput::print("&2[Success]&r&7 Database " . $dbName . ".sqlite created in folder: " . $this->databaseFolder);
     }
 
     /**
@@ -76,7 +81,7 @@ class MakeSQLite
         // Ensure the database folder exists
         if (!is_dir($this->databaseFolder)) {
             mkdir($this->databaseFolder, 0777, true);
-            echo "Database folder created at $this->databaseFolder.\n";
+            ConsoleOutput::print("&8[Info] Database folder created at $this->databaseFolder.");
         }
 
         // Paths for clean and data SQLite files
@@ -86,18 +91,18 @@ class MakeSQLite
         // Create clean SQLite file if it doesn't exist
         if (!file_exists($cleanFilePath)) {
             copy($this->templatesPath . '/database.sqlite', $cleanFilePath);
-            echo "Clean SQLite database file created at $cleanFilePath.\n";
+            ConsoleOutput::print("&8[Info] Clean SQLite database file created at $cleanFilePath.");
         }
 
         // Create data SQLite file if it doesn't exist
         if (!file_exists($dataFilePath)) {
             copy($this->templatesPath . '/database.sqlite', $dataFilePath);
-            echo "SQLite database file created at $dataFilePath.\n";
+            ConsoleOutput::print("&8[Info] SQLite database file created at $dataFilePath.");
         }
 
         // Protect the database with an .htaccess file
         copy($this->templatesPath . '/.htaccess', $this->databaseFolder . '/.htaccess');
-        echo ".htaccess file created to protect the SQLite database.\n";
+        ConsoleOutput::print("&8[Info] .htaccess file created to protect the SQLite database.");
 
         // Create a .gitignore file
         $this->createGitignore($dbName);
@@ -115,7 +120,7 @@ class MakeSQLite
 
         // Save the .gitignore file in the database folder
         file_put_contents($this->databaseFolder . '/.gitignore', $gitignoreContent);
-        echo ".gitignore file created in the database folder.\n";
+        ConsoleOutput::print("&8[Info] .gitignore file created in the database folder.");
     }
 
     /**

--- a/CorianderCore/core/Console/Commands/Hello.php
+++ b/CorianderCore/core/Console/Commands/Hello.php
@@ -2,6 +2,8 @@
 
 namespace CorianderCore\Console\Commands;
 
+use CorianderCore\Console\ConsoleOutput;
+
 class Hello
 {
     /**
@@ -13,7 +15,7 @@ class Hello
      */
     public function execute()
     {
-        echo "Hi! I'm Coriander, how can I help you?" . PHP_EOL;
+        ConsoleOutput::print("Hi! I'm &2Coriander&7, how can I help you?");
     }
 }
 

--- a/CorianderCore/core/Console/Commands/Make.php
+++ b/CorianderCore/core/Console/Commands/Make.php
@@ -2,6 +2,8 @@
 
 namespace CorianderCore\Console\Commands;
 
+use CorianderCore\Console\ConsoleOutput;
+
 /**
  * Class responsible for handling make-related commands such as 'make:view', 'make:controller', and 'make:database'.
  * It delegates the specific subcommands (like view, controller, or database creation) to their respective handlers.
@@ -65,8 +67,7 @@ class Make
     {
         // Ensure the command has at least one argument (the subcommand)
         if (empty($args) || !isset($args[0])) {
-            echo "Error: Invalid make command. Valid commands are: " 
-                 . implode(', ', $this->validSubcommands) . '.' . PHP_EOL;
+            $this->listCommands();
             return;
         }
 
@@ -76,8 +77,8 @@ class Make
         // Verify if the provided subcommand is valid
         if (!in_array($subcommand, $this->validSubcommands)) {
             // Display an error message and list valid subcommands if the subcommand is invalid
-            echo "Error: Unknown make command '{$subcommand}'. Valid commands are: " 
-                 . implode(', ', $this->validSubcommands) . '.' . PHP_EOL;
+            ConsoleOutput::print("&4[Error]&7 Unknown make command: make:{$subcommand}\n");
+            $this->listCommands();
             return;
         }
 
@@ -101,7 +102,7 @@ class Make
             default:
                 // This fallback case is unlikely to be triggered due to the earlier validation,
                 // but serves as a safety net to catch any unforeseen issues.
-                echo "Error: Unknown subcommand '{$subcommand}'." . PHP_EOL;
+                ConsoleOutput::print("&4[Error]&7 Unknown make command: make:{$subcommand}\n");
         }
     }
 
@@ -117,7 +118,7 @@ class Make
     {
         // Ensure a view name is provided
         if (empty($args)) {
-            echo "Error: Please specify a view name, e.g., 'make:view home'." . PHP_EOL;
+            ConsoleOutput::print("&4[Error]&7 Please specify a view name, e.g., 'make:view agenda'");
             return;
         }
 
@@ -137,7 +138,7 @@ class Make
     {
         // Ensure a controller name is provided
         if (empty($args)) {
-            echo "Error: Please specify a controller name, e.g., 'make:controller User'." . PHP_EOL;
+            ConsoleOutput::print("&4[Error]&7 Please specify a controller name, e.g., 'make:controller Agenda'.");
             return;
         }
 
@@ -156,5 +157,18 @@ class Make
     {
         // Delegate the database creation task to the MakeDatabase class
         $this->makeDatabaseInstance->execute($args);
+    }
+
+
+    /**
+     * Lists all available make: commands.
+     */
+    protected function listCommands()
+    {
+        ConsoleOutput::print("Available make commands:");
+
+        foreach ($this->validSubcommands as $cmd) {
+            ConsoleOutput::print("| - make:{$cmd}");
+        }
     }
 }

--- a/CorianderCore/core/Console/Commands/NodeJS.php
+++ b/CorianderCore/core/Console/Commands/NodeJS.php
@@ -2,6 +2,8 @@
 
 namespace CorianderCore\Console\Commands;
 
+use CorianderCore\Console\ConsoleOutput;
+
 class NodeJS
 {
     /**
@@ -17,7 +19,7 @@ class NodeJS
     {
         // Check if any arguments were passed; if not, request a command.
         if (empty($args)) {
-            echo "Please provide a Node.js command to run." . PHP_EOL;
+            ConsoleOutput::print("&4[Error]&7 Please provide a Node.js command to run. (e.g, php coriander nodejs run watch-tw)");
             return;
         }
 
@@ -55,7 +57,7 @@ class NodeJS
             proc_close($process);
         } else {
             // If proc_open failed to start the npm process, output an error message
-            echo "Error: Could not start the process for {$npmCommand}." . PHP_EOL;
+            ConsoleOutput::print("&4[Error]&7 Could not start the process for {$npmCommand}.");
         }
     }
 }

--- a/CorianderCore/core/Console/Commands/View/MakeView.php
+++ b/CorianderCore/core/Console/Commands/View/MakeView.php
@@ -2,6 +2,8 @@
 
 namespace CorianderCore\Console\Commands\View;
 
+use CorianderCore\Console\ConsoleOutput;
+
 /**
  * The MakeView class is responsible for generating new view directories and files
  * based on predefined templates. It facilitates the creation of views in the framework,
@@ -62,11 +64,12 @@ class MakeView
             $this->createFileFromTemplate('view.php', $viewPath . '/index.php', $viewName);
             $this->createFileFromTemplate('metadata.php', $viewPath . '/metadata.php', $viewName);
 
-            echo "View '{$viewName}' created successfully at '{$viewPath}'." . PHP_EOL;
+            ConsoleOutput::print("&2[Success]&r&7 View '{$viewName}' created successfully at '{$viewPath}'.");
 
         } catch (\Exception $e) {
             // Handle any exceptions during the creation process.
             echo $e->getMessage() . PHP_EOL;
+            ConsoleOutput::print("&4[Error]&7 " . $e->getMessage());
         }
     }
 

--- a/CorianderCore/core/Console/ConsoleOutput.php
+++ b/CorianderCore/core/Console/ConsoleOutput.php
@@ -15,6 +15,7 @@ class ConsoleOutput
     const COLOR_BLUE = "\033[34m";
     const COLOR_CYAN = "\033[36m";
     const COLOR_GRAY = "\033[37m";
+    const COLOR_DARK_GRAY = "\033[90m";
     const COLOR_RESET = "\033[0m";
     
     // ANSI style codes
@@ -30,6 +31,7 @@ class ConsoleOutput
      *  - &3: Cyan
      *  - &e: Yellow
      *  - &7: Gray
+     *  - &8: Dark Gray
      *  - &l: Bold
      *  - &u: Underline
      *  - &r: Reset formatting
@@ -42,9 +44,9 @@ class ConsoleOutput
 
         // Replace color codes with corresponding ANSI codes
         $formattedMessage = str_replace([
-            '&4', '&2', '&3', '&e', '&7', '&l', '&u', '&r'
+            '&4', '&2', '&3', '&e', '&7', '&8', '&l', '&u', '&r'
         ], [
-            self::COLOR_RED, self::COLOR_GREEN, self::COLOR_CYAN, self::COLOR_YELLOW, self::COLOR_GRAY, self::STYLE_BOLD, self::STYLE_UNDERLINE, self::STYLE_RESET
+            self::COLOR_RED, self::COLOR_GREEN, self::COLOR_CYAN, self::COLOR_YELLOW, self::COLOR_GRAY, self::COLOR_DARK_GRAY, self::STYLE_BOLD, self::STYLE_UNDERLINE, self::STYLE_RESET
         ], $message);
 
         // Output the formatted message to the console
@@ -56,6 +58,6 @@ class ConsoleOutput
      */
     public static function hr()
     {
-        self::print("-----------------------------------------");
+        self::print("&8-----------------------------------------");
     }
 }

--- a/CorianderCore/tests/AutoloaderTest.php
+++ b/CorianderCore/tests/AutoloaderTest.php
@@ -1,7 +1,6 @@
 <?php
 
 use PHPUnit\Framework\TestCase;
-use Error;
 
 class AutoloaderTest extends TestCase
 {

--- a/CorianderCore/tests/MakeTest.php
+++ b/CorianderCore/tests/MakeTest.php
@@ -7,7 +7,8 @@ use CorianderCore\Console\Commands\View\MakeView;
 class MakeTest extends TestCase
 {
     /**
-     * @var Make Holds the instance of the Make command for testing.
+     * @var Make $make
+     * Holds the instance of the Make command for testing.
      */
     protected $make;
 
@@ -20,7 +21,7 @@ class MakeTest extends TestCase
     {
         // Define PROJECT_ROOT if it hasn't been defined already
         if (!defined('PROJECT_ROOT')) {
-            define('PROJECT_ROOT', dirname(__DIR__, 2));
+            define('PROJECT_ROOT', dirname(__DIR__, 2)); // Set PROJECT_ROOT to the project's root directory.
         }
     }
 
@@ -33,7 +34,7 @@ class MakeTest extends TestCase
     {
         // Create a mock for MakeView, only mocking the 'execute' method
         $mockMakeView = $this->getMockBuilder(MakeView::class)
-            ->onlyMethods(['execute']) // Mock only the 'execute' method
+            ->onlyMethods(['execute']) // Mock only the 'execute' method to simulate its behavior.
             ->getMock();
 
         // Initialize the Make class with the mocked MakeView
@@ -46,18 +47,18 @@ class MakeTest extends TestCase
      */
     public function testMakeViewCommandDelegatesToMakeView()
     {
-        // Create a mock for MakeView, only mocking the 'execute' method
+        // Create a mock for MakeView, mocking only the 'execute' method
         $mockMakeView = $this->getMockBuilder(MakeView::class)
             ->onlyMethods(['execute'])
             ->getMock();
 
-        // Expect that the 'execute' method in the mock will be called once,
-        // with the argument 'home' when make:view is executed
+        // Expect that the 'execute' method in the mock will be called exactly once,
+        // and that it will be called with the argument 'home' when 'make:view home' is executed
         $mockMakeView->expects($this->once())
             ->method('execute')
             ->with($this->equalTo(['home'])); // Expect 'home' as the argument
 
-        // Reinitialize the Make class with the mocked MakeView
+        // Reinitialize the Make class with the newly mocked MakeView
         $this->make = new Make($mockMakeView);
 
         // Simulate running the command: 'php coriander make:view home'
@@ -66,25 +67,25 @@ class MakeTest extends TestCase
 
     /**
      * Tests the output when an invalid make command is passed.
-     * It checks that the error message starts with the correct string.
+     * This test checks that the appropriate error message is displayed when the command is unknown.
      */
     public function testInvalidMakeCommand()
     {
-        // Expect the error message to start with the specified string
-        $this->expectOutputRegex("/^Error: Unknown make command 'invalid'. Valid commands are:/");
+        // Expect the output to contain the error message for an invalid make command
+        $this->expectOutputRegex("/Unknown make command: make:invalid/");
 
-        // Run the make command with an invalid subcommand
+        // Run the make command with an invalid subcommand 'invalid'
         $this->make->execute(['invalid']);
     }
 
     /**
      * Tests the output when no arguments are passed to the make command.
-     * It checks that the error message starts with the correct string.
+     * This test verifies that the error message listing available commands is displayed.
      */
     public function testNoArgumentsPassedToMakeCommand()
     {
-        // Expect the error message to start with the specified string
-        $this->expectOutputRegex("/^Error: Invalid make command. Valid commands are:/");
+        // Expect the output to contain the message listing available make commands
+        $this->expectOutputRegex("/Available make commands:/");
 
         // Run the make command with no arguments
         $this->make->execute([]);
@@ -92,12 +93,12 @@ class MakeTest extends TestCase
 
     /**
      * Tests the output when the 'make:view' command is executed without providing a view name.
-     * It checks that the appropriate error message is displayed.
+     * This test ensures that an appropriate error message is displayed indicating a missing view name.
      */
     public function testMakeViewWithoutViewName()
     {
         // Expect an error message indicating that no view name was provided
-        $this->expectOutputString("Error: Please specify a view name, e.g., 'make:view home'." . PHP_EOL);
+        $this->expectOutputRegex("/Please specify a view name, e.g., 'make:view agenda'/");
 
         // Run the 'make:view' command without providing a view name
         $this->make->execute(['view']);

--- a/CorianderCore/tests/MakeViewTest.php
+++ b/CorianderCore/tests/MakeViewTest.php
@@ -6,9 +6,10 @@ use CorianderCore\Console\Commands\View\MakeView;
 class MakeViewTest extends TestCase
 {
     /**
-     * @var MakeView Holds the instance of the MakeView class for testing.
+     * @var MakeView|\PHPUnit\Framework\MockObject\MockObject $makeView
+     * Holds the instance of the mocked MakeView class for testing.
+     * The methods related to file system operations will be mocked to avoid actual file creation.
      */
-    /** @var MakeView|\PHPUnit\Framework\MockObject\MockObject $mockMakeView */
     protected $makeView;
 
     /**
@@ -20,33 +21,34 @@ class MakeViewTest extends TestCase
     {
         // Define PROJECT_ROOT if it hasn't been defined already
         if (!defined('PROJECT_ROOT')) {
-            define('PROJECT_ROOT', dirname(__DIR__, 2));
+            define('PROJECT_ROOT', dirname(__DIR__, 2)); // Set PROJECT_ROOT to the project's root directory.
         }
     }
 
     /**
      * This method is executed before each test.
-     * It creates a mock of the MakeView class to mock out methods related to file system operations.
-     * The goal is to avoid actual creation of directories or files during testing.
+     * It creates a mock of the MakeView class to mock out methods related to file system operations,
+     * such as 'createDirectory', 'createFileFromTemplate', and 'viewExists'. 
+     * This prevents actual changes to the file system during testing.
      */
     protected function setUp(): void
     {
-        // Create a partial mock for the MakeView class, mocking out 'createDirectory', 'createFileFromTemplate', and 'viewExists'
+        // Create a partial mock for the MakeView class, mocking only the file system methods
         $this->makeView = $this->getMockBuilder(MakeView::class)
-            ->onlyMethods(['createDirectory', 'createFileFromTemplate', 'viewExists']) // Only mock the filesystem-related methods
+            ->onlyMethods(['createDirectory', 'createFileFromTemplate', 'viewExists']) // Mock filesystem-related methods
             ->getMock();
     }
 
     /**
      * Tests the successful creation of a view when it doesn't already exist.
-     * It mocks the necessary file system operations and checks for correct output.
+     * It mocks the necessary file system operations and checks that the correct success message is output.
      */
     public function testCreateViewSuccessfully()
     {
         // Define the expected view path based on PROJECT_ROOT and the view name in kebab-case
         $viewPath = PROJECT_ROOT . '/public/public_views/newview';
 
-        // Mock the 'viewExists' method to return false, simulating that the view does not exist
+        // Mock 'viewExists' to return false, simulating that the view does not exist
         $this->makeView->expects($this->once())
             ->method('viewExists')
             ->with($viewPath)
@@ -58,7 +60,8 @@ class MakeViewTest extends TestCase
             ->with($viewPath);
 
         // Expect the output to indicate successful creation of the view
-        $this->expectOutputString("View 'newview' created successfully at '{$viewPath}'." . PHP_EOL);
+        $this->expectOutputRegex("/Success/");
+        $this->expectOutputRegex("/View 'newview' created successfully at/");
 
         // Run the 'execute' method to trigger view creation
         $this->makeView->execute(['newview']);
@@ -66,21 +69,22 @@ class MakeViewTest extends TestCase
 
     /**
      * Tests the scenario where the view already exists and cannot be created again.
-     * It checks if the appropriate error message is displayed.
+     * It mocks the 'viewExists' method and checks that the appropriate error message is displayed.
      */
     public function testViewAlreadyExists()
     {
         // Define the expected view path for an existing view
         $viewPath = PROJECT_ROOT . '/public/public_views/home';
 
-        // Mock the 'viewExists' method to return true, simulating that the view already exists
+        // Mock 'viewExists' to return true, simulating that the view already exists
         $this->makeView->expects($this->once())
             ->method('viewExists')
             ->with($viewPath)
             ->willReturn(true);
 
         // Expect the output to indicate that the view already exists
-        $this->expectOutputString("Error: View 'home' already exists." . PHP_EOL);
+        $this->expectOutputRegex("/Error/");
+        $this->expectOutputRegex("/'home' already exists./");
 
         // Run the 'execute' method with a view name that already exists
         $this->makeView->execute(['home']);
@@ -88,26 +92,28 @@ class MakeViewTest extends TestCase
 
     /**
      * Tests the scenario where no view name is provided to the 'execute' method.
-     * It checks if the appropriate error message is displayed.
+     * It checks if the appropriate error message is displayed when no arguments are passed.
      */
     public function testNoViewNameProvided()
     {
         // Expect the output to indicate that a view name must be specified
-        $this->expectOutputString("Error: Please specify a view name." . PHP_EOL);
+        $this->expectOutputRegex("/Error/");
+        $this->expectOutputRegex("/Please specify a view name./");
 
         // Run the 'execute' method without providing any arguments
         $this->makeView->execute([]);
     }
 
     /**
-     * Test that the view name is formatted correctly (kebab-case).
+     * Tests that the view name is formatted correctly (kebab-case).
+     * It ensures that even if the input is given in PascalCase, the view is created in kebab-case.
      */
     public function testViewNameFormatting()
     {
         // Define the expected view path with a kebab-case name
         $viewPath = PROJECT_ROOT . '/public/public_views/admin-user';
 
-        // Mock the 'viewExists' method to return false, simulating that the view does not exist
+        // Mock 'viewExists' to return false, simulating that the view does not exist
         $this->makeView->expects($this->once())
             ->method('viewExists')
             ->with($viewPath)
@@ -119,7 +125,8 @@ class MakeViewTest extends TestCase
             ->with($viewPath);
 
         // Expect the output to indicate successful creation of the view
-        $this->expectOutputString("View 'admin-user' created successfully at '{$viewPath}'." . PHP_EOL);
+        $this->expectOutputRegex("/Success/");
+        $this->expectOutputRegex("/View 'admin-user' created successfully at /");
 
         // Run the 'execute' method to trigger view creation with PascalCase input
         $this->makeView->execute(['AdminUser']);


### PR DESCRIPTION
## Issue
#16 & #17

## Summary
- Replace `echo` console output to `Console\ConsoleOutput::print()` function. Refactor:
  - `Console\CommandHandler`
  - `Console\Commands\Hello`
  - `Console\Commands\Make`
  - `Console\Commands\Make\MakeController`
  - `Console\Commands\Make\MakeDatabase`
  - `Console\Commands\Make\MakeView`
  - `Console\Commands\NodeJS`
- Add Dark Gray color for  `Console\ConsoleOutput::print()` function.
- Update related tests to match the new console output format.

## Additional Notes
- All tests passed successfully.