### PR TITLE
19 create new tests for makedatabase

### DIFF
--- a/CorianderCore/core/Console/Commands/Database/MakeDatabase.php
+++ b/CorianderCore/core/Console/Commands/Database/MakeDatabase.php
@@ -4,8 +4,8 @@ namespace CorianderCore\Console\Commands\Database;
 
 use CorianderCore\Console\Commands\Database\MySQL\MakeMySQL;
 use CorianderCore\Console\Commands\Database\SQLite\MakeSQLite;
+use CorianderCore\Console\Services\PdoDriverService;
 use CorianderCore\Console\ConsoleOutput;
-use PDO;
 
 /**
  * The MakeDatabase class is responsible for directing the user to either the MySQL or SQLite setup process.
@@ -14,13 +14,29 @@ use PDO;
 class MakeDatabase
 {
     /**
+     * @var PdoDriverService
+     */
+    protected $pdoDriverService;
+
+    /**
+     * Constructor for MakeDatabase.
+     *
+     * @param PdoDriverService|null $pdoDriverService
+     */
+    public function __construct(PdoDriverService $pdoDriverService = null)
+    {
+        // If no PdoDriverService is passed, instantiate a default one
+        $this->pdoDriverService = $pdoDriverService ?? new PdoDriverService();
+    }
+
+    /**
      * Executes the database configuration process based on user input.
      * Checks for the necessary PDO drivers before prompting the user to choose between MySQL and SQLite.
      */
     public function execute()
     {
         // Check available PDO drivers and warn if MySQL driver is missing
-        $availableDrivers = PDO::getAvailableDrivers();
+        $availableDrivers = $this->pdoDriverService->getAvailableDrivers();
         $mysqlAvailable = in_array('mysql', $availableDrivers);
         $iniPath = php_ini_loaded_file();  // Get the currently loaded php.ini file
 

--- a/CorianderCore/core/Console/Services/PdoDriverService.php
+++ b/CorianderCore/core/Console/Services/PdoDriverService.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace CorianderCore\Console\Services;
+
+class PdoDriverService
+{
+    /**
+     * Get available PDO drivers.
+     *
+     * @return array
+     */
+    public function getAvailableDrivers(): array
+    {
+        return \PDO::getAvailableDrivers();
+    }
+}

--- a/CorianderCore/tests/Make/MakeControllerTest.php
+++ b/CorianderCore/tests/Make/MakeControllerTest.php
@@ -31,7 +31,7 @@ class MakeControllerTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         if (!defined('PROJECT_ROOT')) {
-            define('PROJECT_ROOT', dirname(__DIR__, 2)); // Set PROJECT_ROOT to the project's root directory.
+            define('PROJECT_ROOT', dirname(__DIR__, 3)); // Set PROJECT_ROOT to the project's root directory.
         }
     }
 

--- a/CorianderCore/tests/Make/MakeDatabaseTest.php
+++ b/CorianderCore/tests/Make/MakeDatabaseTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use CorianderCore\Console\Commands\Database\MakeDatabase;
+use CorianderCore\Console\Services\PdoDriverService;
+
+class MakeDatabaseTest extends TestCase
+{
+    /**
+     * @var MakeDatabase
+     */
+    protected $makeDatabase;
+
+    /**
+     * Sets up the necessary conditions before each test, including a mock for PdoDriverService.
+     */
+    protected function setUp(): void
+    {
+        // Mock the PdoDriverService
+        $pdoDriverServiceMock = $this->createMock(PdoDriverService::class);
+        $pdoDriverServiceMock->method('getAvailableDrivers')
+            ->willReturn(['mysql', 'sqlite']);
+
+        // Initialize MakeDatabase with the mocked PdoDriverService
+        $this->makeDatabase = new MakeDatabase($pdoDriverServiceMock);
+    }
+
+    /**
+     * Test the scenario when the MySQL driver is missing, ensuring the warning is displayed.
+     */
+    public function testMissingMysqlDriver()
+    {
+        // Mock the PdoDriverService to simulate missing MySQL
+        $pdoDriverServiceMock = $this->createMock(PdoDriverService::class);
+        $pdoDriverServiceMock->method('getAvailableDrivers')
+            ->willReturn([]);  // MySQL is missing, no drivers
+
+        $this->makeDatabase = new MakeDatabase($pdoDriverServiceMock);
+
+        // Expect the warning message to be printed when MySQL is unavailable
+        $this->expectOutputRegex("/MySQL PDO driver is not available/");
+
+        // Execute the MakeDatabase process
+        $this->makeDatabase->execute();
+    }
+
+    /**
+     * Test the scenario when the MySQL driver is present, ensuring the success symbol is displayed.
+     */
+    public function testNoMissingMysqlDriver()
+    {
+        // Expect the output to contain the checkmark and MySQL in the correct format
+        $this->expectOutputRegex("/1.\s*.*✓\s*.*MySQL/");
+
+        // Execute the MakeDatabase process
+        $this->makeDatabase->execute();
+    }
+}

--- a/CorianderCore/tests/Make/MakeMySQLTest.php
+++ b/CorianderCore/tests/Make/MakeMySQLTest.php
@@ -1,0 +1,120 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use CorianderCore\Console\Commands\Database\MySQL\MakeMySQL;
+use CorianderCore\Console\ConsoleOutput;
+
+class MakeMySQLTest extends TestCase
+{
+    /**
+     * @var MakeMySQL
+     */
+    protected $makeMySQL;
+
+    /**
+     * This method is executed once before any tests are run.
+     * It ensures that the PROJECT_ROOT constant is defined, 
+     * which is essential for path resolution within the framework.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        // Define PROJECT_ROOT if it hasn't been defined already
+        if (!defined('PROJECT_ROOT')) {
+            define('PROJECT_ROOT', dirname(__DIR__, 3)); // Set PROJECT_ROOT to the project's root directory.
+        }
+    }
+
+    /**
+     * Sets up the necessary conditions before each test.
+     * Initializes the MakeMySQL class and mocks ConsoleOutput to suppress actual output.
+     */
+    protected function setUp(): void
+    {
+        // Initialize the MakeMySQL class
+        $this->makeMySQL = new MakeMySQL();
+
+        // Mock the ConsoleOutput class to suppress actual output during tests
+        $consoleOutputMock = $this->getMockBuilder(ConsoleOutput::class)
+            ->onlyMethods(['print', 'hr'])
+            ->getMock();
+
+        // Simulate output behavior
+        $consoleOutputMock->expects($this->any())
+            ->method('print')
+            ->willReturnCallback(function ($message) {
+                echo $message;
+            });
+    }
+
+    /**
+     * Tests the failure scenario when MySQL connection fails, 
+     * and ensures that the appropriate error and warning messages are displayed.
+     */
+    public function testMysqlConnectionFailure()
+    {
+        // Create a temporary directory for the test
+        $tempDir = PROJECT_ROOT . '/test_mysql_config';
+        mkdir($tempDir, 0777, true);
+
+        // Use reflection to set the protected properties
+        $this->setProtectedProperty($this->makeMySQL, 'configPath', $tempDir);
+
+        // Expect the output to indicate an error and warning due to a failed connection
+        $this->expectOutputRegex("/\[Error\].*Connection failed/");
+        $this->expectOutputRegex("/\[Warning\].*Database configuration file not created./");
+
+        // Execute the MakeMySQL process (will fail to connect to the database)
+        $this->makeMySQL->execute();
+
+        // Clean up the temporary directory
+        $this->removeDirectory($tempDir);
+    }
+
+    /**
+     * Clean up the environment after each test.
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * Recursively remove a directory and its contents.
+     *
+     * @param string $dir The directory to remove.
+     */
+    protected function removeDirectory($dir)
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        foreach ($items as $item) {
+            if ($item == '.' || $item == '..') {
+                continue;
+            }
+            $itemPath = $dir . '/' . $item;
+            if (is_dir($itemPath)) {
+                $this->removeDirectory($itemPath);
+            } else {
+                unlink($itemPath);
+            }
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Set a protected or private property on an object via reflection.
+     *
+     * @param object $object The object on which to set the property.
+     * @param string $propertyName The name of the property to set.
+     * @param mixed $value The value to set on the property.
+     */
+    protected function setProtectedProperty($object, $propertyName, $value)
+    {
+        $reflection = new \ReflectionClass($object);
+        $property = $reflection->getProperty($propertyName);
+        $property->setAccessible(true);
+        $property->setValue($object, $value);
+    }
+}

--- a/CorianderCore/tests/Make/MakeSQLiteTest.php
+++ b/CorianderCore/tests/Make/MakeSQLiteTest.php
@@ -1,0 +1,118 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use CorianderCore\Console\Commands\Database\SQLite\MakeSQLite;
+use CorianderCore\Console\ConsoleOutput;
+
+class MakeSQLiteTest extends TestCase
+{
+    /**
+     * @var MakeSQLite
+     */
+    protected $makeSQLite;
+
+    /**
+     * This method is executed once before any tests are run.
+     * It ensures that the PROJECT_ROOT constant is defined, 
+     * which is essential for path resolution within the framework.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        // Define PROJECT_ROOT if it hasn't been defined already
+        if (!defined('PROJECT_ROOT')) {
+            define('PROJECT_ROOT', dirname(__DIR__, 3)); // Set PROJECT_ROOT to the project's root directory.
+        }
+    }
+
+    /**
+     * Sets up the necessary conditions before each test.
+     */
+    protected function setUp(): void
+    {
+        // Initialize the MakeSQLite class
+        $this->makeSQLite = new MakeSQLite();
+
+        // Mock the ConsoleOutput class to suppress actual output during tests
+        $consoleOutputMock = $this->getMockBuilder(ConsoleOutput::class)
+            ->onlyMethods(['print', 'hr'])
+            ->getMock();
+
+        // Simulate output behavior
+        $consoleOutputMock->expects($this->any())
+            ->method('print')
+            ->willReturnCallback(function ($message) {
+                echo $message;
+            });
+    }
+
+    /**
+     * Test the execution of the MakeSQLite process, ensuring it handles SQLite configuration creation.
+     */
+    public function testExecuteSqlite()
+    {
+        // Create a temporary directory for the test
+        $tempDir = PROJECT_ROOT . '/test_sqlite_database';
+        mkdir($tempDir, 0777, true);
+
+        // Use reflection to set the protected properties
+        $this->setProtectedProperty($this->makeSQLite, 'databaseFolder', $tempDir . '');
+        $this->setProtectedProperty($this->makeSQLite, 'configPath', $tempDir . '');
+
+        // Expect the output to indicate success
+        $this->expectOutputRegex("/\[Success\].*Database .sqlite created in folder/");
+
+        // Execute the MakeSQLite process
+        $this->makeSQLite->execute();
+
+        // Clean up the temporary directory
+        $this->removeDirectory($tempDir);
+    }
+
+    /**
+     * Clean up the environment after each test.
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+    }
+
+    /**
+     * Recursively remove a directory and its contents.
+     *
+     * @param string $dir The directory to remove.
+     */
+    protected function removeDirectory($dir)
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        foreach ($items as $item) {
+            if ($item == '.' || $item == '..') {
+                continue;
+            }
+            $itemPath = $dir . '/' . $item;
+            if (is_dir($itemPath)) {
+                $this->removeDirectory($itemPath);
+            } else {
+                unlink($itemPath);
+            }
+        }
+        rmdir($dir);
+    }
+
+    /**
+     * Set a protected or private property on an object via reflection.
+     *
+     * @param object $object The object on which to set the property.
+     * @param string $propertyName The name of the property to set.
+     * @param mixed $value The value to set on the property.
+     */
+    protected function setProtectedProperty($object, $propertyName, $value)
+    {
+        $reflection = new \ReflectionClass($object);
+        $property = $reflection->getProperty($propertyName);
+        $property->setAccessible(true);
+        $property->setValue($object, $value);
+    }
+}

--- a/CorianderCore/tests/Make/MakeTest.php
+++ b/CorianderCore/tests/Make/MakeTest.php
@@ -21,7 +21,7 @@ class MakeTest extends TestCase
     {
         // Define PROJECT_ROOT if it hasn't been defined already
         if (!defined('PROJECT_ROOT')) {
-            define('PROJECT_ROOT', dirname(__DIR__, 2)); // Set PROJECT_ROOT to the project's root directory.
+            define('PROJECT_ROOT', dirname(__DIR__, 3)); // Set PROJECT_ROOT to the project's root directory.
         }
     }
 

--- a/CorianderCore/tests/Make/MakeViewTest.php
+++ b/CorianderCore/tests/Make/MakeViewTest.php
@@ -21,7 +21,7 @@ class MakeViewTest extends TestCase
     {
         // Define PROJECT_ROOT if it hasn't been defined already
         if (!defined('PROJECT_ROOT')) {
-            define('PROJECT_ROOT', dirname(__DIR__, 2)); // Set PROJECT_ROOT to the project's root directory.
+            define('PROJECT_ROOT', dirname(__DIR__, 3)); // Set PROJECT_ROOT to the project's root directory.
         }
     }
 


### PR DESCRIPTION
## Issue
#19 

## Summary
- Moved tests related to the `make:` command into the folder `CorianderCore\tests\Make`.
- Create new class named `PdoDriverService` to assist with mocking PDO-related functions in tests.
- Create test file for `CorianderCore\Console\Commands\Database\MakeDatabase` class.
- Create test file for `CorianderCore\Console\Commands\Database\MySQL\MakeMySQL` class.
- Create test file for `CorianderCore\Console\Commands\Database\SQLite\MakeSQLite` class.

## Additional Notes
- All tests passed successfully.