### PR TITLE
42 create sitemap class

### DIFF
--- a/CorianderCore/core/Console/Commands/Make.php
+++ b/CorianderCore/core/Console/Commands/Make.php
@@ -20,7 +20,8 @@ class Make
     protected $validSubcommands = [
         'view',
         'controller',
-        'database'
+        'database',
+        'sitemap'
     ];
 
     /**
@@ -31,6 +32,7 @@ class Make
     protected $makeViewInstance;
     protected $makeControllerInstance;
     protected $makeDatabaseInstance;
+    protected $makeSitemapInstance;
 
     /**
      * Constructor for the Make class.
@@ -40,6 +42,7 @@ class Make
         $this->makeViewInstance = new \CorianderCore\Console\Commands\Make\View\MakeView();
         $this->makeControllerInstance = new \CorianderCore\Console\Commands\Make\Controller\MakeController();
         $this->makeDatabaseInstance = new \CorianderCore\Console\Commands\Make\Database\MakeDatabase();
+        $this->makeSitemapInstance = new \CorianderCore\Console\Commands\Make\Sitemap\MakeSitemap();
     }
 
     /**
@@ -53,6 +56,7 @@ class Make
      * - 'php coriander make:view home' will create a view named 'home' using the MakeView class.
      * - 'php coriander make:controller User' will create a controller named 'UserController'.
      * - 'php coriander make:database' will initiate the process of database configuration.
+     * - 'php coriander make:sitemap' will create or update the website sitemap.
      *
      * @param array $args The arguments passed to the make command, including the subcommand and resource name.
      */
@@ -90,6 +94,10 @@ class Make
 
             case 'database':
                 $this->makeDatabase($resourceArgs); // Delegate to the MakeDatabase handler
+                break;
+
+            case 'sitemap':
+                $this->makeSitemap($resourceArgs); // Delegate to the MakeSitemap handler
                 break;
 
             default:
@@ -152,6 +160,18 @@ class Make
         $this->makeDatabaseInstance->execute($args);
     }
 
+    /**
+     * Handles the creation of a sitemap by delegating to the MakeSitemap class.
+     * 
+     * This method calls the MakeSitemap class to generate or update the sitemap file.
+     *
+     * @param array $args The arguments for creating or updating the sitemap.
+     */
+    protected function makeSitemap(array $args)
+    {
+        // Delegate the sitemap creation task to the MakeSitemap class
+        $this->makeSitemapInstance->execute($args);
+    }
 
     /**
      * Lists all available make: commands.

--- a/CorianderCore/core/Console/Commands/Make/Sitemap/MakeSitemap.php
+++ b/CorianderCore/core/Console/Commands/Make/Sitemap/MakeSitemap.php
@@ -1,0 +1,102 @@
+<?php
+
+namespace CorianderCore\Console\Commands\Make\Sitemap;
+
+use CorianderCore\Console\ConsoleOutput;
+
+/**
+ * The MakeSitemap class is responsible for generating the sitemap.php file
+ * in the appropriate directory if the developer chooses to create a sitemap.
+ */
+class MakeSitemap
+{
+    /**
+     * @var string $templatesPath The path to the directory containing the sitemap template.
+     */
+    protected string $templatesPath;
+
+    /**
+     * Constructor for the MakeSitemap class.
+     * Initializes the path to the directory where sitemap templates are stored.
+     */
+    public function __construct()
+    {
+        // Set the path to the templates directory.
+        $this->templatesPath = PROJECT_ROOT . '/CorianderCore/core/Console/Commands/Make/Sitemap/templates';
+    }
+
+    /**
+     * Executes the sitemap creation process.
+     * 
+     * This method handles the creation of the sitemap by:
+     * - Verifying if a sitemap already exists.
+     * - Creating the necessary file from a template.
+     *
+     * @param array $args The arguments passed to the command, where the first argument is optional.
+     */
+    public function execute(array $args = []): void
+    {
+        try {
+            // Define the path where the sitemap will be generated.
+            $sitemapFilePath = PROJECT_ROOT . '/public/sitemap.php';
+
+            // Guard clause to prevent overwriting an existing sitemap.
+            if ($this->sitemapExists($sitemapFilePath)) {
+                throw new \Exception("Error: Sitemap already exists at '{$sitemapFilePath}'.");
+            }
+
+            // Create the sitemap file from the template.
+            $this->createFileFromTemplate('sitemap.php', $sitemapFilePath);
+
+            // Success message after sitemap creation.
+            ConsoleOutput::print("&2[Success]&r&7 Sitemap created successfully at '{$sitemapFilePath}'.");
+
+        } catch (\Exception $e) {
+            // Handle any exceptions during the creation process.
+            ConsoleOutput::print("&4[Error]&7 " . $e->getMessage());
+        }
+    }
+
+    /**
+     * Checks if the sitemap file already exists.
+     *
+     * @param string $sitemapFilePath The path to the sitemap.php file.
+     * @return bool True if the sitemap exists, false otherwise.
+     */
+    protected function sitemapExists(string $sitemapFilePath): bool
+    {
+        return file_exists($sitemapFilePath);
+    }
+
+    /**
+     * Copy a template file to the sitemap directory and replace placeholders if needed.
+     * 
+     * This method reads a template file (e.g., sitemap.php), and writes
+     * the content to the destination file.
+     *
+     * @param string $templateFile The name of the template file (e.g., 'sitemap.php').
+     * @param string $destinationFile The full path to the destination file (e.g., the new sitemap.php).
+     */
+    protected function createFileFromTemplate(string $templateFile, string $destinationFile): void
+    {
+        try {
+            // Define the full path to the template file.
+            $templatePath = $this->templatesPath . '/' . $templateFile;
+
+            // Guard clause: Check if the template file exists.
+            if (!file_exists($templatePath)) {
+                throw new \Exception("Error: Template '{$templateFile}' not found.");
+            }
+
+            // Read the content of the template file.
+            $content = file_get_contents($templatePath);
+
+            // Write the content to the destination file.
+            if (file_put_contents($destinationFile, $content) === false) {
+                throw new \Exception("Error: Failed to write to file '{$destinationFile}'.");
+            }
+        } catch (\Exception $e) {
+            throw new \Exception("Error during file creation: " . $e->getMessage());
+        }
+    }
+}

--- a/CorianderCore/core/Console/Commands/Make/Sitemap/templates/sitemap.php
+++ b/CorianderCore/core/Console/Commands/Make/Sitemap/templates/sitemap.php
@@ -1,0 +1,24 @@
+<?php
+// Set the path to the sitemap.xml file
+$sitemapPath = PROJECT_ROOT . '/public/sitemap.xml';
+
+// Check if the sitemap.xml file exists and if it was generated today
+if (!file_exists($sitemapPath) || date('Y-m-d', filemtime($sitemapPath)) !== date('Y-m-d')) {
+    // Initialize the SitemapHandler
+    $sitemapHandler = new \CorianderCore\Sitemap\SitemapHandler();
+
+    // Fetch and add static pages to the sitemap
+    $sitemapHandler->fetchStaticPages();
+
+    // Add dynamic pages to the sitemap (Example)
+    // $sitemapHandler->addDynamicPage(PROJECT_URL . '/blog/post-1', 0.8, '2024-05-01');
+    // $sitemapHandler->addDynamicPage(PROJECT_URL . '/blog/post-1/more-informations', 0.6, '2024-06-15');
+
+    // Generate the sitemap (both static and dynamic pages)
+    $sitemapHandler->generateSitemap();
+}
+
+// Set the content type to XML
+header('Content-Type: application/xml');
+// Output the sitemap.xml file
+readfile($sitemapPath);

--- a/CorianderCore/core/Console/Commands/Make/View/templates/metadata.php
+++ b/CorianderCore/core/Console/Commands/Make/View/templates/metadata.php
@@ -1,15 +1,15 @@
 <?php
 // Set the language attribute for the <html> tag on the {{viewName}} page.
-$lang = !isset($lang) ?: 'en';
+$lang = isset($lang) ? $lang : 'en';
 
 // SEO metadata: Title and meta tags for the {{viewName}} page.
-$metadata = !isset($metadata) ?? '
+$metadata = isset($metadata) ? $metadata : '
 <title>{{viewName}} page</title>
 <meta name="description" content="This is the {{viewName}} page description.">
 ';
 
 // Include this page in the sitemap for SEO purposes.
-$addViewInSitemap = !isset($addViewInSitemap) ?? true;
+$addViewInSitemap = isset($addViewInSitemap) ? $addViewInSitemap : true;
 
 // Set sitemap priority for this page (0.0 - lowest, 1.0 - highest).
-$sitemapPriority = !isset($sitemapPriority) ?? 0.8;
+$sitemapPriority = isset($sitemapPriority) ? $sitemapPriority : 0.8;

--- a/CorianderCore/core/Router/Router.php
+++ b/CorianderCore/core/Router/Router.php
@@ -185,7 +185,7 @@ class Router
      *
      * This method is called when no matching route, controller, or view is found for the request.
      */
-    private static function handleNotFound()
+    public static function handleNotFound()
     {
         if (self::$instance && self::$instance->notFoundCallback) {
             call_user_func(self::$instance->notFoundCallback);

--- a/CorianderCore/core/Sitemap/SitemapHandler.php
+++ b/CorianderCore/core/Sitemap/SitemapHandler.php
@@ -1,0 +1,198 @@
+<?php
+
+namespace CorianderCore\Sitemap;
+
+use SimpleXMLElement;
+
+/**
+ * SitemapHandler is responsible for generating a sitemap by fetching static
+ * views and handling dynamic URLs.
+ */
+class SitemapHandler
+{
+    /**
+     * Path to the public views directory.
+     *
+     * @var string
+     */
+    protected string $viewsPath;
+
+    /**
+     * List to store dynamic pages to be added to the sitemap.
+     *
+     * @var array
+     */
+    protected array $dynamicPages = [];
+
+    /**
+     * Constructor to initialize paths.
+     */
+    public function __construct()
+    {
+        // Set the path to the public views directory.
+        $this->viewsPath = PROJECT_ROOT . '/public/public_views';
+    }
+
+    /**
+     * Fetch all static pages from the public_views directory.
+     *
+     * This function scans the public views directory and retrieves information 
+     * about each static page, including its metadata, last modified date, and 
+     * whether it should be included in the sitemap.
+     *
+     * @return array List of static pages with metadata for sitemap generation.
+     */
+    public function fetchStaticPages(): array
+    {
+        $staticPages = [];
+
+        // Guard clause: Ensure the directory exists before proceeding.
+        if (!is_dir($this->viewsPath)) {
+            return $staticPages;
+        }
+
+        // Scan the public_views directory for view folders.
+        foreach (scandir($this->viewsPath) as $viewDir) {
+            // Guard clause: Skip non-directories and system folders.
+            if ($this->isInvalidDirectory($viewDir)) {
+                continue;
+            }
+
+            // Check if the metadata.php file exists in the view folder.
+            $metadataFile = "{$this->viewsPath}/{$viewDir}/metadata.php";
+            if (!file_exists($metadataFile)) {
+                continue; // Skip views without metadata.
+            }
+
+            // Extract metadata information from the metadata.php file.
+            $metadata = $this->extractMetadata($metadataFile);
+
+            // Guard clause: Skip pages that shouldn't be added to the sitemap.
+            if (!$metadata['addViewInSitemap']) {
+                continue;
+            }
+
+            // Add the static page data to the sitemap list.
+            $staticPages[] = [
+                'url' => PROJECT_URL . "/{$viewDir}",
+                'priority' => $metadata['sitemapPriority'],
+                'lastmod' => $this->getLastModifiedDate("{$this->viewsPath}/{$viewDir}/index.php"),
+            ];
+        }
+
+        return $staticPages;
+    }
+
+    /**
+     * Add dynamic pages to the sitemap.
+     *
+     * @param string $url The URL of the dynamic page.
+     * @param float $priority The priority of the dynamic page (0.0 - 1.0).
+     * @param string|null $lastmod The last modified date (optional).
+     */
+    public function addDynamicPage(string $url, float $priority = 0.5, ?string $lastmod = null): void
+    {
+        // Guard clause: Ensure valid URLs are added to the sitemap.
+        if (empty($url)) {
+            return;
+        }
+
+        // Add the dynamic page to the list.
+        $this->dynamicPages[] = [
+            'url' => $url,
+            'priority' => $priority,
+            'lastmod' => $lastmod ?? date('Y-m-d'),
+        ];
+    }
+
+    /**
+     * Generate the sitemap by combining static and dynamic pages.
+     *
+     * This function generates a sitemap.xml file containing both static and
+     * dynamic pages. It first fetches static pages and then adds dynamic
+     * pages before saving the sitemap to the project directory.
+     */
+    public function generateSitemap(): void
+    {
+        // Create the root element for the XML sitemap.
+        $sitemapXml = new SimpleXMLElement('<urlset/>');
+        $sitemapXml->addAttribute('xmlns', 'http://www.sitemaps.org/schemas/sitemap/0.9');
+
+        // Fetch and add static pages.
+        $staticPages = $this->fetchStaticPages();
+        foreach ($staticPages as $page) {
+            $this->addPageToSitemap($sitemapXml, $page);
+        }
+
+        // Add dynamic pages to the sitemap.
+        foreach ($this->dynamicPages as $page) {
+            $this->addPageToSitemap($sitemapXml, $page);
+        }
+
+        // Save the generated sitemap.xml file to the public directory.
+        $sitemapXml->asXML(PROJECT_ROOT . '/public/sitemap.xml');
+    }
+
+    /**
+     * Add a page (static or dynamic) to the sitemap XML structure.
+     *
+     * @param SimpleXMLElement $sitemapXml The XML element for the sitemap.
+     * @param array $page The page data (url, priority, lastmod).
+     */
+    protected function addPageToSitemap(SimpleXMLElement $sitemapXml, array $page): void
+    {
+        $urlElement = $sitemapXml->addChild('url');
+        $urlElement->addChild('loc', $page['url']);
+        $urlElement->addChild('lastmod', $page['lastmod']);
+        $urlElement->addChild('priority', (string)$page['priority']);
+    }
+
+    /**
+     * Extract metadata from a metadata.php file.
+     *
+     * This function retrieves metadata information for each view, including
+     * whether the view should be included in the sitemap and its priority.
+     *
+     * @param string $metadataFile Path to the metadata file.
+     * @return array Metadata information for the sitemap.
+     */
+    protected function extractMetadata(string $metadataFile): array
+    {
+        include $metadataFile;
+
+        // Return metadata with sensible defaults.
+        return [
+            'addViewInSitemap' => $addViewInSitemap ?? false,
+            'sitemapPriority' => $sitemapPriority ?? 0.5,
+        ];
+    }
+
+    /**
+     * Get the last modified date of a file.
+     *
+     * This function retrieves the last modified date of a file and returns it
+     * in 'Y-m-d' format for use in the sitemap.
+     *
+     * @param string $filePath Path to the file.
+     * @return string Date in 'Y-m-d' format.
+     */
+    protected function getLastModifiedDate(string $filePath): string
+    {
+        return date('Y-m-d', filemtime($filePath));
+    }
+
+    /**
+     * Check if a directory is invalid for sitemap generation.
+     *
+     * This function checks if a directory should be skipped, such as system
+     * directories or non-directory files.
+     *
+     * @param string $dir The directory name.
+     * @return bool True if invalid, false otherwise.
+     */
+    protected function isInvalidDirectory(string $dir): bool
+    {
+        // Guard clause to check for non-directories and system directories.
+        return $dir === '.' || $dir === '..' || !is_dir($this->viewsPath . '/' . $dir);
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -36,6 +36,15 @@ $router->setNotFound(function () {
     require_once PROJECT_ROOT . '/public/public_views/footer.php';
 });
 
+$router->add('sitemap.xml', function () use ($router) {
+    $sitemapPath = PROJECT_ROOT . '/public/sitemap.php';
+    if (!file_exists($sitemapPath)) {
+        $router->handleNotFound();
+        return;
+    }
+    require_once $sitemapPath;
+});
+
 // Dispatch the request to the correct view or controller
 $router->dispatch();
 

--- a/public/public_views/home/metadata.php
+++ b/public/public_views/home/metadata.php
@@ -1,15 +1,15 @@
 <?php
 // Set the language attribute for the <html> tag on the home page.
-$lang = !isset($lang) ?: 'en';
+$lang = isset($lang) ? $lang : 'en';
 
 // SEO metadata: Title and meta tags for the home page.
-$metadata = !isset($metadata) ?? '
+$metadata = isset($metadata) ? $metadata : '
 <title>home page</title>
 <meta name="description" content="This is the home page description.">
 ';
 
 // Include this page in the sitemap for SEO purposes.
-$addViewInSitemap = !isset($addViewInSitemap) ?? true;
+$addViewInSitemap = isset($addViewInSitemap) ? $addViewInSitemap : true;
 
 // Set sitemap priority for this page (0.0 - lowest, 1.0 - highest).
-$sitemapPriority = !isset($sitemapPriority) ?? 0.8;
+$sitemapPriority = isset($sitemapPriority) ? $sitemapPriority : 0.8;

--- a/public/public_views/notfound/metadata.php
+++ b/public/public_views/notfound/metadata.php
@@ -1,9 +1,9 @@
 <?php
 // Set the language attribute for the <html> tag on the notfound page.
-$lang = !isset($lang) ?: 'en';
+$lang = isset($lang) ? $lang : 'en';
 
 // SEO metadata: Title and meta tags for the notfound page.
-$metadata = !isset($metadata) ?? '
+$metadata = isset($metadata) ? $metadata : '
 <title>notfound page</title>
 <meta name="description" content="This is the notfound page description.">
 ';


### PR DESCRIPTION
## Issue
#42 & #43

## Summary
- Resolved bad use of ternary operator in the metadata template and files.
- Added SitemapHandler class.
- Added MakeSitemap class.
- Added `make:sitemap` subcommand.

## Additional Notes
- All tests passed successfully.