### PR TITLE
51 refactor unit tests

### DIFF
--- a/CorianderCore/core/Console/Commands/Make/Controller/MakeController.php
+++ b/CorianderCore/core/Console/Commands/Make/Controller/MakeController.php
@@ -17,14 +17,22 @@ class MakeController
     protected $templatesPath;
 
     /**
+     * @var string $basePath The base path where controllers will be created.
+     */
+    protected $basePath;
+
+    /**
      * Constructor for the MakeController class.
      * 
-     * Initializes the path to the directory where controller templates are stored.
-     * The templates will be copied to the correct location during controller creation.
+     * Initializes the path to the directory where controller templates are stored,
+     * and sets the base path where controllers will be generated.
+     * 
+     * @param string $basePath The base path where controllers will be stored (default: PROJECT_ROOT . '/src/Controllers/').
      */
-    public function __construct()
+    public function __construct(string $basePath = PROJECT_ROOT . '/src/Controllers/')
     {
-        // Set the path to the templates directory.
+        // Set the path to the base controller directory and templates directory.
+        $this->basePath = $basePath;
         $this->templatesPath = PROJECT_ROOT . '/CorianderCore/core/Console/Commands/Make/Controller/templates';
     }
 
@@ -33,7 +41,7 @@ class MakeController
      * 
      * This method handles the creation of a new controller by:
      * - Verifying if a controller name is provided.
-     * - Ensuring the controller name is properly formatted.
+     * - Ensuring the controller name follows the proper naming conventions.
      * - Checking if the controller already exists.
      * - Creating the necessary file using a template.
      *
@@ -47,7 +55,7 @@ class MakeController
             return;
         }
 
-        // Format the controller name (convert to PascalCase with multiple uppercase if necessary).
+        // Format the controller name (convert to PascalCase).
         $controllerName = $this->formatControllerName($args[0]);
 
         // Ensure the controller name ends with "Controller".
@@ -55,11 +63,11 @@ class MakeController
             $controllerName .= 'Controller';
         }
 
-        // Convert to kebab-case for view paths.
+        // Convert to kebab-case for potential view paths.
         $kebabCaseName = $this->toKebabCase($args[0]);
 
-        // Determine the path where the controller will be created.
-        $controllerPath = PROJECT_ROOT . '/src/Controllers/' . $controllerName . '.php';
+        // Determine the full path where the controller will be created.
+        $controllerPath = $this->basePath . $controllerName . '.php';
 
         // Ensure the directory exists.
         $this->ensureDirectoryExists(dirname($controllerPath));
@@ -90,7 +98,7 @@ class MakeController
      */
     protected function formatControllerName(string $name): string
     {
-        // Convert kebab-case or snake_case to PascalCase and maintain proper casing for multiple words
+        // Convert kebab-case or snake_case to PascalCase.
         return str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $name)));
     }
 
@@ -104,7 +112,7 @@ class MakeController
      */
     protected function toKebabCase(string $string): string
     {
-        // Convert PascalCase or camelCase to kebab-case (all lowercase, words separated by dashes)
+        // Convert PascalCase or camelCase to kebab-case.
         return strtolower(preg_replace('/([a-z])([A-Z])/', '$1-$2', $string));
     }
 
@@ -149,7 +157,7 @@ class MakeController
      * @param string $templateFile The name of the template file (e.g., 'Controller.php').
      * @param string $destinationFile The full path to the destination file (e.g., the new controller's file).
      * @param string $controllerName The name of the controller (used to replace placeholders in the template).
-     * @param string $kebabCaseName The kebab-case version of the controller name for the view paths.
+     * @param string $kebabCaseName The kebab-case version of the controller name for view paths.
      * @throws \Exception If the template file cannot be written.
      */
     protected function createFileFromTemplate(string $templateFile, string $destinationFile, string $controllerName, string $kebabCaseName)

--- a/CorianderCore/core/Console/Commands/Make/Database/MySQL/MakeMySQL.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/MySQL/MakeMySQL.php
@@ -24,12 +24,14 @@ class MakeMySQL
 
     /**
      * Constructor to initialize paths for templates and configuration files.
+     * 
+     * @param string $configPath Path to the configuration folder (default: PROJECT_ROOT . '/config').
      */
-    public function __construct()
+    public function __construct(string $configPath = PROJECT_ROOT . '/config')
     {
         // Define paths to the MySQL templates and config folder
         $this->templatesPath = PROJECT_ROOT . '/CorianderCore/core/Console/Commands/Make/Database/MySQL/templates';
-        $this->configPath = PROJECT_ROOT . '/config';
+        $this->configPath = $configPath;
     }
 
     /**

--- a/CorianderCore/core/Console/Commands/Make/Database/SQLite/MakeSQLite.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/SQLite/MakeSQLite.php
@@ -25,30 +25,41 @@ class MakeSQLite
     protected $databaseFolder;
 
     /**
-     * Constructor to initialize paths for templates and configuration files.
+     * Constructor to initialize paths for templates, configuration files, and database folder.
+     * 
+     * @param string $configPath Path to the configuration folder (default: PROJECT_ROOT . '/config').
+     * @param string $databaseFolder Path to the database folder (default: PROJECT_ROOT . '/database').
      */
-    public function __construct()
-    {
-        // Define paths to the SQLite templates and configuration folder
+    public function __construct(
+        string $configPath = PROJECT_ROOT . '/config',
+        string $databaseFolder = PROJECT_ROOT . '/database'
+    ) {
+        // Define paths to the SQLite templates, config, and database folder
         $this->templatesPath = PROJECT_ROOT . '/CorianderCore/core/Console/Commands/Make/Database/SQLite/templates';
-        $this->configPath = PROJECT_ROOT . '/config';
-        $this->databaseFolder = PROJECT_ROOT . '/database';
+        $this->configPath = $configPath;
+        $this->databaseFolder = $databaseFolder;
     }
 
     /**
      * Executes the process of creating an SQLite configuration.
-     * Prompts the user for the SQLite database name and generates necessary files.
+     * Optionally accepts a database name. If not provided, prompts the user for the SQLite database name.
+     *
+     * @param string|null $dbName Optional database name. If null, prompts the user for input.
      */
-    public function execute()
+    public function execute(string $dbName = null)
     {
-        // Ask the user for the SQLite database name
-        ConsoleOutput::print("Enter SQLite database name (without extension):\n");
-        $dbName = trim(fgets(STDIN));
+        // Ask the user for the SQLite database name if not provided
+        if (empty($dbName)) {
+            ConsoleOutput::print("Enter SQLite database name (without extension):\n");
+            $dbName = trim(fgets(STDIN));
+        }
+
         ConsoleOutput::hr();
 
         // Generate SQLite configuration and database files
         $this->generateConfig($dbName);
         $this->createDatabaseFiles($dbName);
+
         ConsoleOutput::hr();
         ConsoleOutput::print("&2[Success]&r&7 Database " . $dbName . ".sqlite created in folder: " . $this->databaseFolder);
     }

--- a/CorianderCore/core/Console/Commands/Make/Sitemap/MakeSitemap.php
+++ b/CorianderCore/core/Console/Commands/Make/Sitemap/MakeSitemap.php
@@ -7,50 +7,56 @@ use CorianderCore\Console\ConsoleOutput;
 /**
  * The MakeSitemap class is responsible for generating the sitemap.php file
  * in the appropriate directory if the developer chooses to create a sitemap.
+ * 
+ * This class handles the creation of a new sitemap by verifying whether a sitemap
+ * already exists and, if not, creating the necessary file from a template.
  */
 class MakeSitemap
 {
     /**
-     * @var string $templatesPath The path to the directory containing the sitemap template.
+     * @var string $templatesPath The path to the directory containing the sitemap template file.
      */
     protected string $templatesPath;
 
     /**
-     * Constructor for the MakeSitemap class.
-     * Initializes the path to the directory where sitemap templates are stored.
+     * @var string $sitemapFilePath The path where the sitemap will be generated.
      */
-    public function __construct()
+    protected string $sitemapFilePath;
+
+    /**
+     * Constructor for the MakeSitemap class.
+     * Initializes the path to the directory where sitemap templates are stored and the path where the sitemap will be created.
+     * 
+     * @param string $sitemapFilePath The path where the sitemap will be generated (default: PROJECT_ROOT . '/public/sitemap.php').
+     */
+    public function __construct(string $sitemapFilePath = PROJECT_ROOT . '/public/sitemap.php')
     {
-        // Set the path to the templates directory.
+        $this->sitemapFilePath = $sitemapFilePath;
         $this->templatesPath = PROJECT_ROOT . '/CorianderCore/core/Console/Commands/Make/Sitemap/templates';
     }
 
     /**
      * Executes the sitemap creation process.
      * 
-     * This method handles the creation of the sitemap by:
-     * - Verifying if a sitemap already exists.
-     * - Creating the necessary file from a template.
-     *
-     * @param array $args The arguments passed to the command, where the first argument is optional.
+     * This method checks if a sitemap already exists at the specified path. If it does not exist, 
+     * it creates the sitemap from a predefined template and stores it in the provided path.
+     * 
+     * - If a sitemap already exists, an error message is displayed.
+     * - If the sitemap is successfully created, a success message is displayed.
      */
-    public function execute(array $args = []): void
+    public function execute(): void
     {
         try {
-            // Define the path where the sitemap will be generated.
-            $sitemapFilePath = PROJECT_ROOT . '/public/sitemap.php';
-
             // Guard clause to prevent overwriting an existing sitemap.
-            if ($this->sitemapExists($sitemapFilePath)) {
-                throw new \Exception("Error: Sitemap already exists at '{$sitemapFilePath}'.");
+            if ($this->sitemapExists($this->sitemapFilePath)) {
+                throw new \Exception("Error: Sitemap already exists at '{$this->sitemapFilePath}'.");
             }
 
             // Create the sitemap file from the template.
-            $this->createFileFromTemplate('sitemap.php', $sitemapFilePath);
+            $this->createFileFromTemplate('sitemap.php', $this->sitemapFilePath);
 
             // Success message after sitemap creation.
-            ConsoleOutput::print("&2[Success]&r&7 Sitemap created successfully at '{$sitemapFilePath}'.");
-
+            ConsoleOutput::print("&2[Success]&r&7 Sitemap created successfully at '{$this->sitemapFilePath}'.");
         } catch (\Exception $e) {
             // Handle any exceptions during the creation process.
             ConsoleOutput::print("&4[Error]&7 " . $e->getMessage());
@@ -59,6 +65,8 @@ class MakeSitemap
 
     /**
      * Checks if the sitemap file already exists.
+     *
+     * This method checks if a sitemap file already exists at the provided file path.
      *
      * @param string $sitemapFilePath The path to the sitemap.php file.
      * @return bool True if the sitemap exists, false otherwise.
@@ -69,13 +77,14 @@ class MakeSitemap
     }
 
     /**
-     * Copy a template file to the sitemap directory and replace placeholders if needed.
+     * Copies a template file to the sitemap directory and writes its content to the destination.
      * 
-     * This method reads a template file (e.g., sitemap.php), and writes
-     * the content to the destination file.
+     * This method reads the content of a template file (e.g., sitemap.php) and writes the content to
+     * the destination file path. It throws exceptions in case of any file errors during the process.
      *
      * @param string $templateFile The name of the template file (e.g., 'sitemap.php').
-     * @param string $destinationFile The full path to the destination file (e.g., the new sitemap.php).
+     * @param string $destinationFile The full path to the destination file where the content will be written.
+     * @throws \Exception If the template file does not exist or the destination file cannot be written.
      */
     protected function createFileFromTemplate(string $templateFile, string $destinationFile): void
     {

--- a/CorianderCore/core/Utils/DirectoryHandler.php
+++ b/CorianderCore/core/Utils/DirectoryHandler.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace CorianderCore\Utils;
+
+/**
+ * The DirectoryHandler class provides utilities for working with directories.
+ * It includes methods for creating directories and recursively deleting directories with their contents.
+ */
+class DirectoryHandler
+{
+    /**
+     * Recursively delete a directory and its contents.
+     *
+     * This method deletes all files and subdirectories within the specified directory,
+     * and then removes the directory itself.
+     *
+     * @param string $dirPath The path to the directory to delete.
+     */
+    public static function deleteDirectory(string $dirPath): void
+    {
+        // If the directory doesn't exist, exit the method.
+        if (!is_dir($dirPath)) {
+            return;
+        }
+
+        // Get all files and subdirectories within the directory, excluding '.' and '..'.
+        $files = array_diff(scandir($dirPath), ['.', '..']);
+
+        // Recursively delete files and subdirectories.
+        foreach ($files as $file) {
+            $filePath = "$dirPath/$file";
+            // If it's a directory, recurse into it. Otherwise, delete the file.
+            is_dir($filePath) ? self::deleteDirectory($filePath) : unlink($filePath);
+        }
+
+        // Remove the directory itself after its contents have been deleted.
+        rmdir($dirPath);
+    }
+
+    /**
+     * Create a new directory if it doesn't exist.
+     * 
+     * This method attempts to create a new directory with the specified path.
+     * If the directory cannot be created, an exception is thrown.
+     *
+     * @param string $viewPath The path to the directory to be created.
+     * @throws \Exception If the directory cannot be created.
+     */
+    public static function createDirectory(string $viewPath): void
+    {
+        try {
+            // Attempt to create the directory with 0755 permissions. If it fails and the directory doesn't exist, throw an error.
+            if (!mkdir($viewPath, 0755, true) && !is_dir($viewPath)) {
+                throw new \Exception("Error: Failed to create directory '{$viewPath}'.");
+            }
+        } catch (\Exception $e) {
+            // Rethrow the exception with an additional error message.
+            throw new \Exception("Error: Unable to create view directory. " . $e->getMessage());
+        }
+    }
+}

--- a/CorianderCore/tests/ImageHandlerTest.php
+++ b/CorianderCore/tests/ImageHandlerTest.php
@@ -2,6 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 use CorianderCore\Image\ImageHandler;
+use CorianderCore\Utils\DirectoryHandler;
 
 /**
  * Class ImageHandlerTest
@@ -16,6 +17,11 @@ use CorianderCore\Image\ImageHandler;
  */
 class ImageHandlerTest extends TestCase
 {
+    /**
+     * @var string Path to the temporary directory for testing.
+     */
+    protected static $testPath;
+
     // Directories and file paths for testing
     private static $testImageDir;
     private static $testImagePath;
@@ -36,6 +42,9 @@ class ImageHandlerTest extends TestCase
         if (!defined('PROJECT_ROOT')) {
             define('PROJECT_ROOT', dirname(__DIR__, 2));
         }
+
+        // Set the path to the temporary test directory
+        self::$testPath = PROJECT_ROOT . "/CorianderCore/tests/_tmp";
     }
 
     
@@ -48,8 +57,8 @@ class ImageHandlerTest extends TestCase
             );
         }
         
-        self::$testImageDir = PROJECT_ROOT . '/CorianderCore/tests/assets/';
-        self::$testImagePath = '/CorianderCore/tests/assets/test_image.png';
+        self::$testImageDir = self::$testPath . '/assets/';
+        self::$testImagePath = '/CorianderCore/tests/_tmp/assets/test_image.png';
         self::$webpDir = 'webp/';
         self::$testImageFullPath = self::$testImageDir . 'test_image.png';
         self::$testWebpFullPath = self::$testImageDir . self::$webpDir . 'test_image_80.webp';
@@ -66,6 +75,20 @@ class ImageHandlerTest extends TestCase
             imagefilledrectangle($image, 0, 0, 100, 100, $backgroundColor);
             imagepng($image, self::$testImageFullPath);
             imagedestroy($image);
+        }
+    }
+    
+    /**
+     * tearDownAfterClass
+     *
+     * This method runs once after all tests in the class have completed.
+     * It cleans up the test environment by removing test files and directories.
+     */
+    public static function tearDownAfterClass(): void
+    {
+        // Cleanup: Remove test files and directories if they exist
+        if (is_dir(self::$testPath)) {
+            DirectoryHandler::deleteDirectory(self::$testPath); // Cleanup the temporary directory.
         }
     }
 
@@ -90,7 +113,7 @@ class ImageHandlerTest extends TestCase
     public function testConvertToWebp()
     {
         // Test conversion to WebP format
-        $webpPath = ImageHandler::convertToWebP(self::$testImagePath, 80);
+        ImageHandler::convertToWebP(self::$testImagePath, 80);
 
         $this->assertFileExists(
             self::$testImageDir . self::$webpDir . 'test_image_80.webp',
@@ -110,33 +133,7 @@ class ImageHandlerTest extends TestCase
         $html = ImageHandler::render(self::$testImagePath, 'Test Image', 'picture-class', 'img-class', 80);
 
         $this->assertStringContainsString('<picture class="picture-class">', $html, 'Picture tag was not rendered correctly.');
-        $this->assertStringContainsString('<source srcset="/CorianderCore/tests/assets/webp/test_image_80.webp" type="image/webp"', $html, 'WebP source tag was not rendered correctly.');
-        $this->assertStringContainsString('<img alt=\'Test Image\' width="100" height="100" class="img-class" src="/CorianderCore/tests/assets/test_image.png"', $html, 'Image tag was not rendered correctly.');
-    }
-
-    /**
-     * tearDownAfterClass
-     *
-     * This method runs once after all tests in the class have completed.
-     * It cleans up the test environment by removing test files and directories.
-     */
-    public static function tearDownAfterClass(): void
-    {
-        // Cleanup: Remove test image and WebP files if they exist
-        if (file_exists(self::$testImageFullPath)) {
-            unlink(self::$testImageFullPath);
-        }
-
-        if (file_exists(self::$testWebpFullPath)) {
-            unlink(self::$testWebpFullPath);
-        }
-
-        if (is_dir(self::$testImageDir . self::$webpDir)) {
-            rmdir(self::$testImageDir . self::$webpDir);
-        }
-
-        if (is_dir(self::$testImageDir)) {
-            rmdir(self::$testImageDir);
-        }
+        $this->assertStringContainsString('<source srcset="/CorianderCore/tests/_tmp/assets/webp/test_image_80.webp" type="image/webp"', $html, 'WebP source tag was not rendered correctly.');
+        $this->assertStringContainsString('<img alt=\'Test Image\' width="100" height="100" class="img-class" src="/CorianderCore/tests/_tmp/assets/test_image.png"', $html, 'Image tag was not rendered correctly.');
     }
 }

--- a/CorianderCore/tests/Make/MakeSQLiteTest.php
+++ b/CorianderCore/tests/Make/MakeSQLiteTest.php
@@ -3,6 +3,7 @@
 use PHPUnit\Framework\TestCase;
 use CorianderCore\Console\Commands\Make\Database\SQLite\MakeSQLite;
 use CorianderCore\Console\ConsoleOutput;
+use CorianderCore\Utils\DirectoryHandler;
 
 class MakeSQLiteTest extends TestCase
 {
@@ -12,9 +13,14 @@ class MakeSQLiteTest extends TestCase
     protected $makeSQLite;
 
     /**
+     * @var string Path to the temporary directory for testing.
+     */
+    protected static $testPath;
+
+    /**
      * This method is executed once before any tests are run.
      * It ensures that the PROJECT_ROOT constant is defined, 
-     * which is essential for path resolution within the framework.
+     * and sets the test path to a temporary folder.
      */
     public static function setUpBeforeClass(): void
     {
@@ -22,6 +28,9 @@ class MakeSQLiteTest extends TestCase
         if (!defined('PROJECT_ROOT')) {
             define('PROJECT_ROOT', dirname(__DIR__, 3)); // Set PROJECT_ROOT to the project's root directory.
         }
+
+        // Set the path to the temporary test directory
+        self::$testPath = PROJECT_ROOT . "/CorianderCore/tests/_tmp";
     }
 
     /**
@@ -29,8 +38,13 @@ class MakeSQLiteTest extends TestCase
      */
     protected function setUp(): void
     {
-        // Initialize the MakeSQLite class
-        $this->makeSQLite = new MakeSQLite();
+        // Ensure the test path exists
+        if (!is_dir(self::$testPath)) {
+            mkdir(self::$testPath, 0777, true);
+        }
+
+        // Initialize the MakeSQLite class with custom paths
+        $this->makeSQLite = new MakeSQLite(self::$testPath . '/config', self::$testPath . '/database');
 
         // Mock the ConsoleOutput class to suppress actual output during tests
         $consoleOutputMock = $this->getMockBuilder(ConsoleOutput::class)
@@ -44,75 +58,34 @@ class MakeSQLiteTest extends TestCase
                 echo $message;
             });
     }
+    
+    /**
+     * tearDownAfterClass
+     *
+     * This method runs once after all tests in the class have completed.
+     * It cleans up the test environment by removing test files and directories.
+     */
+    public static function tearDownAfterClass(): void
+    {
+        // Cleanup: Remove test files and directories if they exist
+        if (is_dir(self::$testPath)) {
+            DirectoryHandler::deleteDirectory(self::$testPath); // Cleanup the temporary directory.
+        }
+    }
 
     /**
      * Test the execution of the MakeSQLite process, ensuring it handles SQLite configuration creation.
      */
     public function testExecuteSqlite()
     {
-        // Create a temporary directory for the test
-        $tempDir = PROJECT_ROOT . '/CorianderCore/tests/test_sqlite_database';
-        mkdir($tempDir, 0777, true);
-
-        // Use reflection to set the protected properties
-        $this->setProtectedProperty($this->makeSQLite, 'databaseFolder', $tempDir . '');
-        $this->setProtectedProperty($this->makeSQLite, 'configPath', $tempDir . '');
+        // Execute the MakeSQLite process
+        $this->makeSQLite->execute('test');
 
         // Expect the output to indicate success
-        $this->expectOutputRegex("/\[Success\].*Database .sqlite created in folder/");
-
-        // Execute the MakeSQLite process
-        $this->makeSQLite->execute();
-
-        // Clean up the temporary directory
-        $this->removeDirectory($tempDir);
-    }
-
-    /**
-     * Clean up the environment after each test.
-     */
-    protected function tearDown(): void
-    {
-        parent::tearDown();
-    }
-
-    /**
-     * Recursively remove a directory and its contents.
-     *
-     * @param string $dir The directory to remove.
-     */
-    protected function removeDirectory($dir)
-    {
-        if (!is_dir($dir)) {
-            return;
-        }
-        $items = scandir($dir);
-        foreach ($items as $item) {
-            if ($item == '.' || $item == '..') {
-                continue;
-            }
-            $itemPath = $dir . '/' . $item;
-            if (is_dir($itemPath)) {
-                $this->removeDirectory($itemPath);
-            } else {
-                unlink($itemPath);
-            }
-        }
-        rmdir($dir);
-    }
-
-    /**
-     * Set a protected or private property on an object via reflection.
-     *
-     * @param object $object The object on which to set the property.
-     * @param string $propertyName The name of the property to set.
-     * @param mixed $value The value to set on the property.
-     */
-    protected function setProtectedProperty($object, $propertyName, $value)
-    {
-        $reflection = new \ReflectionClass($object);
-        $property = $reflection->getProperty($propertyName);
-        $property->setAccessible(true);
-        $property->setValue($object, $value);
+        $this->expectOutputRegex("/\[Success\].*Database test.sqlite created in folder/");
+        // Check if the SQLite files and config file were created
+        $this->assertFileExists(self::$testPath . '/database/clean_test.sqlite');
+        $this->assertFileExists(self::$testPath . '/database/test.sqlite');
+        $this->assertFileExists(self::$testPath . '/config/database.php');
     }
 }

--- a/CorianderCore/tests/Make/MakeViewTest.php
+++ b/CorianderCore/tests/Make/MakeViewTest.php
@@ -2,20 +2,24 @@
 
 use PHPUnit\Framework\TestCase;
 use CorianderCore\Console\Commands\Make\View\MakeView;
+use CorianderCore\Utils\DirectoryHandler;
 
 class MakeViewTest extends TestCase
 {
     /**
-     * @var MakeView|\PHPUnit\Framework\MockObject\MockObject $makeView
-     * Holds the instance of the mocked MakeView class for testing.
-     * The methods related to file system operations will be mocked to avoid actual file creation.
+     * @var MakeView Holds the instance of the MakeView class for testing.
      */
     protected $makeView;
 
     /**
+     * @var string Path to the temporary directory for testing.
+     */
+    protected static $testPath;
+
+    /**
      * This method is executed once before any tests are run.
      * It ensures that the PROJECT_ROOT constant is defined,
-     * which is essential for resolving paths during the test.
+     * and sets the test path to a temporary folder.
      */
     public static function setUpBeforeClass(): void
     {
@@ -23,71 +27,70 @@ class MakeViewTest extends TestCase
         if (!defined('PROJECT_ROOT')) {
             define('PROJECT_ROOT', dirname(__DIR__, 3)); // Set PROJECT_ROOT to the project's root directory.
         }
+
+        // Set the path to the temporary test directory
+        self::$testPath = PROJECT_ROOT . "/CorianderCore/tests/_tmp/";
     }
 
     /**
-     * This method is executed before each test.
-     * It creates a mock of the MakeView class to mock out methods related to file system operations,
-     * such as 'createDirectory', 'createFileFromTemplate', and 'viewExists'. 
-     * This prevents actual changes to the file system during testing.
+     * Sets up the necessary conditions before each test.
+     * It ensures the test directory exists and initializes the MakeView class
+     * with the test path as the view path.
      */
     protected function setUp(): void
     {
-        // Create a partial mock for the MakeView class, mocking only the file system methods
-        $this->makeView = $this->getMockBuilder(MakeView::class)
-            ->onlyMethods(['createDirectory', 'createFileFromTemplate', 'viewExists']) // Mock filesystem-related methods
-            ->getMock();
+        // Ensure the test path exists
+        if (!is_dir(self::$testPath)) {
+            mkdir(self::$testPath, 0777, true);
+        }
+
+        // Initialize the MakeView class with the test path as the view path
+        $this->makeView = new MakeView(self::$testPath);
+    }
+
+    /**
+     * This method runs once after all tests in the class have completed.
+     * It cleans up the test environment by removing the temporary test directory and its contents.
+     */
+    public static function tearDownAfterClass(): void
+    {
+        // Cleanup: Remove test files and directories if they exist
+        if (is_dir(self::$testPath)) {
+            DirectoryHandler::deleteDirectory(self::$testPath); // Cleanup the temporary directory.
+        }
     }
 
     /**
      * Tests the successful creation of a view when it doesn't already exist.
-     * It mocks the necessary file system operations and checks that the correct success message is output.
+     * Checks that the correct success message is output after the view creation.
      */
     public function testCreateViewSuccessfully()
     {
-        // Define the expected view path based on PROJECT_ROOT and the view name in kebab-case
-        $viewPath = PROJECT_ROOT . '/public/public_views/newview';
+        $viewName = "newview";
 
-        // Mock 'viewExists' to return false, simulating that the view does not exist
-        $this->makeView->expects($this->once())
-            ->method('viewExists')
-            ->with($viewPath)
-            ->willReturn(false);
-
-        // Mock the creation of the directory where the view will be stored
-        $this->makeView->expects($this->once())
-            ->method('createDirectory')
-            ->with($viewPath);
+        // Run the 'execute' method to trigger view creation
+        $this->makeView->execute([$viewName]);
 
         // Expect the output to indicate successful creation of the view
         $this->expectOutputRegex("/Success/");
         $this->expectOutputRegex("/View 'newview' created successfully at/");
-
-        // Run the 'execute' method to trigger view creation
-        $this->makeView->execute(['newview']);
     }
 
     /**
      * Tests the scenario where the view already exists and cannot be created again.
-     * It mocks the 'viewExists' method and checks that the appropriate error message is displayed.
+     * It simulates the creation of a view, then checks that the appropriate error message is displayed 
+     * when attempting to create the same view again.
      */
     public function testViewAlreadyExists()
     {
-        // Define the expected view path for an existing view
-        $viewPath = PROJECT_ROOT . '/public/public_views/home';
+        $viewName = "newview";
 
-        // Mock 'viewExists' to return true, simulating that the view already exists
-        $this->makeView->expects($this->once())
-            ->method('viewExists')
-            ->with($viewPath)
-            ->willReturn(true);
+        // Simulate the first creation of the view
+        $this->makeView->execute([$viewName]);
 
         // Expect the output to indicate that the view already exists
         $this->expectOutputRegex("/Error/");
-        $this->expectOutputRegex("/'home' already exists./");
-
-        // Run the 'execute' method with a view name that already exists
-        $this->makeView->execute(['home']);
+        $this->expectOutputRegex("/'newview' already exists./");
     }
 
     /**
@@ -105,30 +108,18 @@ class MakeViewTest extends TestCase
     }
 
     /**
-     * Tests that the view name is formatted correctly (kebab-case).
+     * Tests that the view name is formatted correctly as kebab-case.
      * It ensures that even if the input is given in PascalCase, the view is created in kebab-case.
      */
     public function testViewNameFormatting()
     {
-        // Define the expected view path with a kebab-case name
-        $viewPath = PROJECT_ROOT . '/public/public_views/admin-user';
+        $viewName = "AdminUser";
 
-        // Mock 'viewExists' to return false, simulating that the view does not exist
-        $this->makeView->expects($this->once())
-            ->method('viewExists')
-            ->with($viewPath)
-            ->willReturn(false);
-
-        // Mock the creation of the directory
-        $this->makeView->expects($this->once())
-            ->method('createDirectory')
-            ->with($viewPath);
+        // Run the 'execute' method to trigger view creation with PascalCase input
+        $this->makeView->execute([$viewName]);
 
         // Expect the output to indicate successful creation of the view
         $this->expectOutputRegex("/Success/");
         $this->expectOutputRegex("/View 'admin-user' created successfully at /");
-
-        // Run the 'execute' method to trigger view creation with PascalCase input
-        $this->makeView->execute(['AdminUser']);
     }
 }

--- a/CorianderCore/tests/SitemapHandlerTest.php
+++ b/CorianderCore/tests/SitemapHandlerTest.php
@@ -2,7 +2,7 @@
 
 use PHPUnit\Framework\TestCase;
 use CorianderCore\Sitemap\SitemapHandler;
-use SimpleXMLElement;
+use CorianderCore\Utils\DirectoryHandler;
 
 /**
  * Class SitemapHandlerTest
@@ -53,6 +53,20 @@ class SitemapHandlerTest extends TestCase
 
         file_put_contents($viewDir . '/metadata.php', "<?php\n\$addViewInSitemap = true;\n\$sitemapPriority = 0.8;");
         file_put_contents($viewDir . '/index.php', "<h1>Sample View</h1>");
+    }
+    
+    /**
+     * tearDownAfterClass
+     *
+     * This method runs once after all tests in the class have completed.
+     * It cleans up the test environment by removing test files and directories.
+     */
+    public static function tearDownAfterClass(): void
+    {
+        // Cleanup: Remove test files and directories if they exist
+        if (is_dir(self::$testPath)) {
+            DirectoryHandler::deleteDirectory(self::$testPath); // Cleanup the temporary directory.
+        }
     }
 
     /**
@@ -108,39 +122,5 @@ class SitemapHandlerTest extends TestCase
         $sitemapXml = simplexml_load_file($sitemapFilePath);
         $this->assertInstanceOf(SimpleXMLElement::class, $sitemapXml, 'Sitemap XML could not be loaded.');
         $this->assertCount(2, $sitemapXml->url, 'Sitemap XML does not contain the expected number of URLs.');
-    }
-
-    /**
-     * tearDownAfterClass
-     *
-     * This method runs once after all tests in the class have completed.
-     * It cleans up the test environment by removing test files and directories.
-     */
-    public static function tearDownAfterClass(): void
-    {
-        // Cleanup: Remove test files and directories if they exist
-        $viewDir = self::$viewsPath . '/sampleView';
-        if (is_dir($viewDir)) {
-            unlink($viewDir . '/metadata.php');
-            unlink($viewDir . '/index.php');
-            rmdir($viewDir);
-        }
-
-        if (is_dir(self::$viewsPath)) {
-            rmdir(self::$viewsPath);
-        }
-
-        $sitemapFilePath = self::$outputDir . 'sitemap.xml';
-        if (file_exists($sitemapFilePath)) {
-            unlink($sitemapFilePath);
-        }
-
-        if (is_dir(self::$outputDir)) {
-            rmdir(self::$outputDir);
-        }
-
-        if(is_dir(self::$testPath)) {
-            rmdir(self::$testPath);
-        }
     }
 }


### PR DESCRIPTION
## Issue
#51

## Summary
- Refactored the `tearDown` methods across all unit tests that create temporary files or directories, ensuring proper cleanup of these resources after each test.
- All test files are now created and stored in the `/CorianderCore/tests/_tmp/` directory.
- Some classes were refactored to accept an additional argument in their constructors, which improves testability by allowing the injection of the temporary directory path during tests.
- Centralized directory creation and deletion functionality in a new `DirectoryHandler` utility class.

## Additional Notes
- All tests passed successfully.
- The `_tmp` directory is automatically cleaned up after each test execution, with no leftover files or folders.