### PR TITLE
refactor: adopt PSR-4 namespaces and autoloader

### DIFF
--- a/CorianderCore/autoload.php
+++ b/CorianderCore/autoload.php
@@ -2,71 +2,32 @@
 
 /**
  * CorianderPHP Autoloader
- * 
- * This autoloader dynamically loads PHP classes in the CorianderPHP framework based on the PSR-4 standard.
- * The autoloader automatically resolves and includes class files by mapping namespaces to directory structures.
- * 
- * It supports two primary class paths:
- * 
- * 1. **Core Framework Modules** (`core/` directory):
- *    - The `core/` directory contains all the essential modules required for the framework to function.
- *    - For example, the class `CorianderCore\Console\CommandHandler` will be mapped to:
- *      `CorianderCore/core/Console/CommandHandler.php`
- * 
- * 2. **User-Defined Modules** (`modules/` directory):
- *    - The `modules/` directory holds any user-defined modules that extend or modify the framework's behavior.
- *    - For example, the class `CustomModule\Google\GoogleSSO` will be mapped to:
- *      `CorianderCore/modules/CustomModule/Google/GoogleSSO.php`
- * 
- * ### Functionality
- * 
- * The autoloader follows these steps:
- * 
- * - Strips the `CorianderCore\` prefix from class names (if applicable) to align with the file structure.
- * - Converts the namespace into a file path by replacing namespace separators (`\`) with directory separators (`/`).
- * - Searches through the core and modules directories to locate the correct file for the class.
- * - If the class file is found, it is included. If not, an exception is thrown with an error message.
- * 
- * @param string $class The fully-qualified class name (namespace included).
- * @throws Exception If the class file cannot be located in any of the directories.
+ *
+ * Provides PSR-4 compliant class loading using a simple namespace-to-directory map.
+ *
+ * Supported namespace prefixes:
+ * - `CorianderCore\\Core\\`    → `/CorianderCore/core/`
+ * - `CorianderCore\\Modules\\` → `/CorianderCore/modules/`
+ * - `CorianderCore\\Tests\\`   → `/CorianderCore/tests/`
+ *
+ * @param string $class Fully-qualified class name
  */
-
-spl_autoload_register(function ($class) {
-    /**
-     * Base directories to search for class files.
-     *
-     * - `/CorianderCore/core/`: Contains core framework modules.
-     * - `/CorianderCore/modules/`: Contains user-defined or external modules.
-     * - `/src/`: Contains Controllers, Models and user-defined classes.
-     */
-    $baseDirs = [
-        PROJECT_ROOT . '/CorianderCore/core/',    // Core framework modules directory
-        PROJECT_ROOT . '/CorianderCore/modules/', // External user-defined modules directory
-        PROJECT_ROOT . '/src/',                   // Controllers, Models and user-defined classes
+spl_autoload_register(function (string $class): void {
+    $prefixes = [
+        'CorianderCore\\Core\\'    => PROJECT_ROOT . '/CorianderCore/core/',
+        'CorianderCore\\Modules\\' => PROJECT_ROOT . '/CorianderCore/modules/',
+        'CorianderCore\\Tests\\'   => PROJECT_ROOT . '/CorianderCore/tests/',
     ];
 
-    /**
-     * Convert the namespace to a relative file path.
-     * 
-     * 1. Remove the "CorianderCore\" prefix from class names.
-     * 2. Replace the namespace separator (`\`) with the directory separator (`/`).
-     * 3. Append the `.php` file extension.
-     * 
-     * Example: `CorianderCore\Console\CommandHandler` becomes `Console/CommandHandler.php`.
-     * 
-     * @var string $relativeClassPath The relative file path derived from the class name.
-     */
-    $relativeClassPath = str_replace('CorianderCore\\', '', $class);
-    $relativeClassPath = str_replace('\\', '/', $relativeClassPath) . '.php';
-
-    // Search through the defined base directories for the class file
-    foreach ($baseDirs as $baseDir) {
-        $file = $baseDir . $relativeClassPath;
-
-        // If the class file is found, require it
+    foreach ($prefixes as $prefix => $baseDir) {
+        $len = strlen($prefix);
+        if (strncmp($class, $prefix, $len) !== 0) {
+            continue;
+        }
+        $relative = substr($class, $len);
+        $file = $baseDir . str_replace('\\', '/', $relative) . '.php';
         if (file_exists($file)) {
             require_once $file;
-            return;
         }
     }
 });

--- a/CorianderCore/core/Benchmark/BenchmarkHandler.php
+++ b/CorianderCore/core/Benchmark/BenchmarkHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Benchmark;
+namespace CorianderCore\Core\Benchmark;
 
 /**
  * BenchmarkHandler is responsible for measuring key performance indicators

--- a/CorianderCore/core/Console/CommandHandler.php
+++ b/CorianderCore/core/Console/CommandHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Console;
+namespace CorianderCore\Core\Console;
 
 class CommandHandler
 {
@@ -10,10 +10,10 @@ class CommandHandler
      * @var array
      */
     protected $commands = [
-        'hello' => \CorianderCore\Console\Commands\Hello::class,
-        'nodejs' => \CorianderCore\Console\Commands\NodeJS::class,
-        'make' => \CorianderCore\Console\Commands\Make::class,
-        'benchmark' => \CorianderCore\Console\Commands\Benchmark::class,
+        'hello' => \CorianderCore\Core\Console\Commands\Hello::class,
+        'nodejs' => \CorianderCore\Core\Console\Commands\NodeJS::class,
+        'make' => \CorianderCore\Core\Console\Commands\Make::class,
+        'benchmark' => \CorianderCore\Core\Console\Commands\Benchmark::class,
     ];
 
     /**

--- a/CorianderCore/core/Console/Commands/Benchmark.php
+++ b/CorianderCore/core/Console/Commands/Benchmark.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CorianderCore\Console\Commands;
+namespace CorianderCore\Core\Console\Commands;
 
-use CorianderCore\Console\ConsoleOutput;
+use CorianderCore\Core\Console\ConsoleOutput;
 
 /**
  * Benchmark is responsible for handling benchmark-related commands such as 'benchmark:router'.
@@ -32,7 +32,7 @@ class Benchmark
      */
     public function __construct()
     {
-        $this->benchmarkRouterInstance = new \CorianderCore\Console\Commands\Benchmark\BenchmarkRouter();
+        $this->benchmarkRouterInstance = new \CorianderCore\Core\Console\Commands\Benchmark\BenchmarkRouter();
     }
 
     /**

--- a/CorianderCore/core/Console/Commands/Benchmark/BenchmarkRouter.php
+++ b/CorianderCore/core/Console/Commands/Benchmark/BenchmarkRouter.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace CorianderCore\Console\Commands\Benchmark;
+namespace CorianderCore\Core\Console\Commands\Benchmark;
 
-use CorianderCore\Benchmark\BenchmarkHandler;
-use CorianderCore\Console\ConsoleOutput;
-use CorianderCore\Router\Router;
+use CorianderCore\Core\Benchmark\BenchmarkHandler;
+use CorianderCore\Core\Console\ConsoleOutput;
+use CorianderCore\Core\Router\Router;
 
 /**
  * BenchmarkRouter handles benchmarking related to routing performance.

--- a/CorianderCore/core/Console/Commands/Hello.php
+++ b/CorianderCore/core/Console/Commands/Hello.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CorianderCore\Console\Commands;
+namespace CorianderCore\Core\Console\Commands;
 
-use CorianderCore\Console\ConsoleOutput;
+use CorianderCore\Core\Console\ConsoleOutput;
 
 class Hello
 {

--- a/CorianderCore/core/Console/Commands/Make.php
+++ b/CorianderCore/core/Console/Commands/Make.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CorianderCore\Console\Commands;
+namespace CorianderCore\Core\Console\Commands;
 
-use CorianderCore\Console\ConsoleOutput;
+use CorianderCore\Core\Console\ConsoleOutput;
 
 /**
  * Class responsible for handling make-related commands such as 'make:view', 'make:controller', and 'make:database'.
@@ -39,10 +39,10 @@ class Make
      */
     public function __construct()
     {
-        $this->makeViewInstance = new \CorianderCore\Console\Commands\Make\View\MakeView();
-        $this->makeControllerInstance = new \CorianderCore\Console\Commands\Make\Controller\MakeController();
-        $this->makeDatabaseInstance = new \CorianderCore\Console\Commands\Make\Database\MakeDatabase();
-        $this->makeSitemapInstance = new \CorianderCore\Console\Commands\Make\Sitemap\MakeSitemap();
+        $this->makeViewInstance = new \CorianderCore\Core\Console\Commands\Make\View\MakeView();
+        $this->makeControllerInstance = new \CorianderCore\Core\Console\Commands\Make\Controller\MakeController();
+        $this->makeDatabaseInstance = new \CorianderCore\Core\Console\Commands\Make\Database\MakeDatabase();
+        $this->makeSitemapInstance = new \CorianderCore\Core\Console\Commands\Make\Sitemap\MakeSitemap();
     }
 
     /**

--- a/CorianderCore/core/Console/Commands/Make/Controller/MakeController.php
+++ b/CorianderCore/core/Console/Commands/Make/Controller/MakeController.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CorianderCore\Console\Commands\Make\Controller;
+namespace CorianderCore\Core\Console\Commands\Make\Controller;
 
-use CorianderCore\Console\ConsoleOutput;
+use CorianderCore\Core\Console\ConsoleOutput;
 
 /**
  * The MakeController class is responsible for generating new controller files

--- a/CorianderCore/core/Console/Commands/Make/Controller/templates/ApiController.php
+++ b/CorianderCore/core/Console/Commands/Make/Controller/templates/ApiController.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace ApiControllers;
+namespace CorianderCore\Core\Console\Commands\Make\Controller\templates;
 
 /**
  * Class {{controllerName}}

--- a/CorianderCore/core/Console/Commands/Make/Controller/templates/WebController.php
+++ b/CorianderCore/core/Console/Commands/Make/Controller/templates/WebController.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace Controllers;
+namespace CorianderCore\Core\Console\Commands\Make\Controller\templates;
 
-use CorianderCore\Router\ViewRenderer;
+use CorianderCore\Core\Router\ViewRenderer;
 
 /**
  * Class {{controllerName}}

--- a/CorianderCore/core/Console/Commands/Make/Database/MakeDatabase.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/MakeDatabase.php
@@ -1,11 +1,11 @@
 <?php
 
-namespace CorianderCore\Console\Commands\Make\Database;
+namespace CorianderCore\Core\Console\Commands\Make\Database;
 
-use CorianderCore\Console\Commands\Make\Database\MySQL\MakeMySQL;
-use CorianderCore\Console\Commands\Make\Database\SQLite\MakeSQLite;
-use CorianderCore\Console\Services\PdoDriverService;
-use CorianderCore\Console\ConsoleOutput;
+use CorianderCore\Core\Console\Commands\Make\Database\MySQL\MakeMySQL;
+use CorianderCore\Core\Console\Commands\Make\Database\SQLite\MakeSQLite;
+use CorianderCore\Core\Console\Services\PdoDriverService;
+use CorianderCore\Core\Console\ConsoleOutput;
 
 /**
  * The MakeDatabase class is responsible for directing the user to either the MySQL or SQLite setup process.

--- a/CorianderCore/core/Console/Commands/Make/Database/MySQL/MakeMySQL.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/MySQL/MakeMySQL.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CorianderCore\Console\Commands\Make\Database\MySQL;
+namespace CorianderCore\Core\Console\Commands\Make\Database\MySQL;
 
-use CorianderCore\Console\ConsoleOutput;
+use CorianderCore\Core\Console\ConsoleOutput;
 use \PDO;
 use \PDOException;
 

--- a/CorianderCore/core/Console/Commands/Make/Database/SQLite/MakeSQLite.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/SQLite/MakeSQLite.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CorianderCore\Console\Commands\Make\Database\SQLite;
+namespace CorianderCore\Core\Console\Commands\Make\Database\SQLite;
 
-use CorianderCore\Console\ConsoleOutput;
+use CorianderCore\Core\Console\ConsoleOutput;
 
 /**
  * The MakeSQLite class is responsible for generating and setting up SQLite database configurations.

--- a/CorianderCore/core/Console/Commands/Make/Sitemap/MakeSitemap.php
+++ b/CorianderCore/core/Console/Commands/Make/Sitemap/MakeSitemap.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CorianderCore\Console\Commands\Make\Sitemap;
+namespace CorianderCore\Core\Console\Commands\Make\Sitemap;
 
-use CorianderCore\Console\ConsoleOutput;
+use CorianderCore\Core\Console\ConsoleOutput;
 
 /**
  * The MakeSitemap class is responsible for generating the sitemap.php file

--- a/CorianderCore/core/Console/Commands/Make/Sitemap/templates/sitemap.php
+++ b/CorianderCore/core/Console/Commands/Make/Sitemap/templates/sitemap.php
@@ -5,7 +5,7 @@ $sitemapPath = PROJECT_ROOT . '/public/sitemap.xml';
 // Check if the sitemap.xml file exists and if it was generated today
 if (!file_exists($sitemapPath) || date('Y-m-d', filemtime($sitemapPath)) !== date('Y-m-d')) {
     // Initialize the SitemapHandler
-    $sitemapHandler = new \CorianderCore\Sitemap\SitemapHandler();
+    $sitemapHandler = new \CorianderCore\Core\Sitemap\SitemapHandler();
 
     // Fetch and add static pages to the sitemap
     $sitemapHandler->fetchStaticPages();

--- a/CorianderCore/core/Console/Commands/Make/View/MakeView.php
+++ b/CorianderCore/core/Console/Commands/Make/View/MakeView.php
@@ -1,9 +1,9 @@
 <?php
 
-namespace CorianderCore\Console\Commands\Make\View;
+namespace CorianderCore\Core\Console\Commands\Make\View;
 
-use CorianderCore\Console\ConsoleOutput;
-use CorianderCore\Utils\DirectoryHandler;
+use CorianderCore\Core\Console\ConsoleOutput;
+use CorianderCore\Core\Utils\DirectoryHandler;
 
 /**
  * The MakeView class is responsible for generating new view directories and files

--- a/CorianderCore/core/Console/Commands/NodeJS.php
+++ b/CorianderCore/core/Console/Commands/NodeJS.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CorianderCore\Console\Commands;
+namespace CorianderCore\Core\Console\Commands;
 
-use CorianderCore\Console\ConsoleOutput;
+use CorianderCore\Core\Console\ConsoleOutput;
 
 class NodeJS
 {

--- a/CorianderCore/core/Console/ConsoleOutput.php
+++ b/CorianderCore/core/Console/ConsoleOutput.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Console;
+namespace CorianderCore\Core\Console;
 
 /**
  * The ConsoleOutput class handles console output with custom color

--- a/CorianderCore/core/Console/Services/PdoDriverService.php
+++ b/CorianderCore/core/Console/Services/PdoDriverService.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Console\Services;
+namespace CorianderCore\Core\Console\Services;
 
 class PdoDriverService
 {

--- a/CorianderCore/core/Database/DatabaseHandler.php
+++ b/CorianderCore/core/Database/DatabaseHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Database;
+namespace CorianderCore\Core\Database;
 
 use \PDO;
 

--- a/CorianderCore/core/Database/SQLManager.php
+++ b/CorianderCore/core/Database/SQLManager.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace CorianderCore\Database;
+namespace CorianderCore\Core\Database;
 
 use \PDO;
 use Exception;
-use CorianderCore\Database\DatabaseHandler;
+use CorianderCore\Core\Database\DatabaseHandler;
 
 class SQLManager
 {

--- a/CorianderCore/core/Image/ImageHandler.php
+++ b/CorianderCore/core/Image/ImageHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Image;
+namespace CorianderCore\Core\Image;
 
 /**
  * Handles image conversion and rendering for PNG, JPG, and JPEG files.

--- a/CorianderCore/core/Router/ApiControllerHandler.php
+++ b/CorianderCore/core/Router/ApiControllerHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Router;
+namespace CorianderCore\Core\Router;
 
 /**
  * Handles dispatching to API controllers based on RESTful methods and subpaths.

--- a/CorianderCore/core/Router/NameFormatter.php
+++ b/CorianderCore/core/Router/NameFormatter.php
@@ -1,13 +1,13 @@
 <?php
 
-namespace CorianderCore\Router;
+namespace CorianderCore\Core\Router;
 
 /**
  * Utility class for formatting controller and route names.
  *
  * Converts URI segments to PascalCase to match controller class naming conventions.
  *
- * @package CorianderCore\Router
+ * @package CorianderCore\Core\Router
  */
 class NameFormatter
 {

--- a/CorianderCore/core/Router/NotFoundHandler.php
+++ b/CorianderCore/core/Router/NotFoundHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Router;
+namespace CorianderCore\Core\Router;
 
 /**
  * Handles 404 not found logic.

--- a/CorianderCore/core/Router/RouteDispatcher.php
+++ b/CorianderCore/core/Router/RouteDispatcher.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Router;
+namespace CorianderCore\Core\Router;
 
 /**
  * Determines whether to dispatch a Web, API, or custom route.

--- a/CorianderCore/core/Router/RouteRegistry.php
+++ b/CorianderCore/core/Router/RouteRegistry.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Router;
+namespace CorianderCore\Core\Router;
 
 /**
  * Manages custom routes and 404 callback.

--- a/CorianderCore/core/Router/Router.php
+++ b/CorianderCore/core/Router/Router.php
@@ -1,10 +1,10 @@
 <?php
 
-namespace CorianderCore\Router;
+namespace CorianderCore\Core\Router;
 
-use CorianderCore\Router\RouteDispatcher;
-use CorianderCore\Router\RouteRegistry;
-use CorianderCore\Router\NotFoundHandler;
+use CorianderCore\Core\Router\RouteDispatcher;
+use CorianderCore\Core\Router\RouteRegistry;
+use CorianderCore\Core\Router\NotFoundHandler;
 
 /**
  * Entry point for route dispatching.

--- a/CorianderCore/core/Router/ViewRenderer.php
+++ b/CorianderCore/core/Router/ViewRenderer.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Router;
+namespace CorianderCore\Core\Router;
 
 /**
  * Renders public view pages.

--- a/CorianderCore/core/Router/WebControllerHandler.php
+++ b/CorianderCore/core/Router/WebControllerHandler.php
@@ -1,8 +1,8 @@
 <?php
 
-namespace CorianderCore\Router;
+namespace CorianderCore\Core\Router;
 
-use CorianderCore\Router\NameFormatter;
+use CorianderCore\Core\Router\NameFormatter;
 
 /**
  * Handles dispatching to web controllers by resolving controller class and action from a URL path.
@@ -12,7 +12,7 @@ use CorianderCore\Router\NameFormatter;
  * - Loading the appropriate controller file if needed.
  * - Invoking the controller action method based on HTTP method and URI segments.
  *
- * @package CorianderCore\Router
+ * @package CorianderCore\Core\Router
  */
 class WebControllerHandler
 {

--- a/CorianderCore/core/Sitemap/SitemapHandler.php
+++ b/CorianderCore/core/Sitemap/SitemapHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Sitemap;
+namespace CorianderCore\Core\Sitemap;
 
 use SimpleXMLElement;
 

--- a/CorianderCore/core/Utils/DirectoryHandler.php
+++ b/CorianderCore/core/Utils/DirectoryHandler.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace CorianderCore\Utils;
+namespace CorianderCore\Core\Utils;
 
 /**
  * The DirectoryHandler class provides utilities for working with directories.

--- a/CorianderCore/tests/AutoloaderTest.php
+++ b/CorianderCore/tests/AutoloaderTest.php
@@ -25,7 +25,7 @@ class AutoloaderTest extends TestCase
     public function testCanLoadCoreClass()
     {
         // Assert that the CommandHandler class exists and is autoloaded correctly
-        $this->assertTrue(class_exists('CorianderCore\Console\CommandHandler'));
+        $this->assertTrue(class_exists('CorianderCore\Core\Console\CommandHandler'));
     }
 
     /**

--- a/CorianderCore/tests/BenchmarkHandlerTest.php
+++ b/CorianderCore/tests/BenchmarkHandlerTest.php
@@ -2,7 +2,7 @@
 
 namespace CorianderCore\Tests;
 
-use CorianderCore\Benchmark\BenchmarkHandler;
+use CorianderCore\Core\Benchmark\BenchmarkHandler;
 use PHPUnit\Framework\TestCase;
 
 /**

--- a/CorianderCore/tests/CommandHandlerTest.php
+++ b/CorianderCore/tests/CommandHandlerTest.php
@@ -3,7 +3,7 @@
 namespace CorianderCore\Tests;
 
 use PHPUnit\Framework\TestCase;
-use CorianderCore\Console\CommandHandler;
+use CorianderCore\Core\Console\CommandHandler;
 
 class CommandHandlerTest extends TestCase
 {

--- a/CorianderCore/tests/ImageHandlerTest.php
+++ b/CorianderCore/tests/ImageHandlerTest.php
@@ -3,8 +3,8 @@
 namespace CorianderCore\Tests;
 
 use PHPUnit\Framework\TestCase;
-use CorianderCore\Image\ImageHandler;
-use CorianderCore\Utils\DirectoryHandler;
+use CorianderCore\Core\Image\ImageHandler;
+use CorianderCore\Core\Utils\DirectoryHandler;
 
 /**
  * Class ImageHandlerTest

--- a/CorianderCore/tests/Make/MakeControllerTest.php
+++ b/CorianderCore/tests/Make/MakeControllerTest.php
@@ -3,8 +3,8 @@
 namespace CorianderCore\Tests\Make;
 
 use PHPUnit\Framework\TestCase;
-use CorianderCore\Console\Commands\Make\Controller\MakeController;
-use CorianderCore\Utils\DirectoryHandler;
+use CorianderCore\Core\Console\Commands\Make\Controller\MakeController;
+use CorianderCore\Core\Utils\DirectoryHandler;
 
 /**
  * The MakeControllerTest class contains unit tests for the MakeController class.

--- a/CorianderCore/tests/Make/MakeDatabaseTest.php
+++ b/CorianderCore/tests/Make/MakeDatabaseTest.php
@@ -3,8 +3,8 @@
 namespace CorianderCore\Tests\Make;
 
 use PHPUnit\Framework\TestCase;
-use CorianderCore\Console\Commands\Make\Database\MakeDatabase;
-use CorianderCore\Console\Services\PdoDriverService;
+use CorianderCore\Core\Console\Commands\Make\Database\MakeDatabase;
+use CorianderCore\Core\Console\Services\PdoDriverService;
 
 class MakeDatabaseTest extends TestCase
 {

--- a/CorianderCore/tests/Make/MakeMySQLTest.php
+++ b/CorianderCore/tests/Make/MakeMySQLTest.php
@@ -3,9 +3,9 @@
 namespace CorianderCore\Tests\Make;
 
 use PHPUnit\Framework\TestCase;
-use CorianderCore\Console\Commands\Make\Database\MySQL\MakeMySQL;
-use CorianderCore\Console\ConsoleOutput;
-use CorianderCore\Utils\DirectoryHandler;
+use CorianderCore\Core\Console\Commands\Make\Database\MySQL\MakeMySQL;
+use CorianderCore\Core\Console\ConsoleOutput;
+use CorianderCore\Core\Utils\DirectoryHandler;
 
 class MakeMySQLTest extends TestCase
 {

--- a/CorianderCore/tests/Make/MakeSQLiteTest.php
+++ b/CorianderCore/tests/Make/MakeSQLiteTest.php
@@ -3,9 +3,9 @@
 namespace CorianderCore\Tests\Make;
 
 use PHPUnit\Framework\TestCase;
-use CorianderCore\Console\Commands\Make\Database\SQLite\MakeSQLite;
-use CorianderCore\Console\ConsoleOutput;
-use CorianderCore\Utils\DirectoryHandler;
+use CorianderCore\Core\Console\Commands\Make\Database\SQLite\MakeSQLite;
+use CorianderCore\Core\Console\ConsoleOutput;
+use CorianderCore\Core\Utils\DirectoryHandler;
 
 class MakeSQLiteTest extends TestCase
 {

--- a/CorianderCore/tests/Make/MakeSitemapTest.php
+++ b/CorianderCore/tests/Make/MakeSitemapTest.php
@@ -3,8 +3,8 @@
 namespace CorianderCore\Tests\Make;
 
 use PHPUnit\Framework\TestCase;
-use CorianderCore\Console\Commands\Make\Sitemap\MakeSitemap;
-use CorianderCore\Utils\DirectoryHandler;
+use CorianderCore\Core\Console\Commands\Make\Sitemap\MakeSitemap;
+use CorianderCore\Core\Utils\DirectoryHandler;
 
 class MakeSitemapTest extends TestCase
 {

--- a/CorianderCore/tests/Make/MakeViewTest.php
+++ b/CorianderCore/tests/Make/MakeViewTest.php
@@ -3,8 +3,8 @@
 namespace CorianderCore\Tests\Make;
 
 use PHPUnit\Framework\TestCase;
-use CorianderCore\Console\Commands\Make\View\MakeView;
-use CorianderCore\Utils\DirectoryHandler;
+use CorianderCore\Core\Console\Commands\Make\View\MakeView;
+use CorianderCore\Core\Utils\DirectoryHandler;
 
 class MakeViewTest extends TestCase
 {

--- a/CorianderCore/tests/MakeTest.php
+++ b/CorianderCore/tests/MakeTest.php
@@ -3,8 +3,8 @@
 namespace CorianderCore\Tests;
 
 use PHPUnit\Framework\TestCase;
-use CorianderCore\Console\Commands\Make;
-use CorianderCore\Console\Commands\Make\View\MakeView;
+use CorianderCore\Core\Console\Commands\Make;
+use CorianderCore\Core\Console\Commands\Make\View\MakeView;
 
 class MakeTest extends TestCase
 {

--- a/CorianderCore/tests/RouterTest.php
+++ b/CorianderCore/tests/RouterTest.php
@@ -3,7 +3,7 @@
 namespace CorianderCore\Tests;
 
 use PHPUnit\Framework\TestCase;
-use CorianderCore\Router\Router;
+use CorianderCore\Core\Router\Router;
 
 class RouterTest extends TestCase
 {

--- a/CorianderCore/tests/SitemapHandlerTest.php
+++ b/CorianderCore/tests/SitemapHandlerTest.php
@@ -3,8 +3,8 @@
 namespace CorianderCore\Tests;
 
 use PHPUnit\Framework\TestCase;
-use CorianderCore\Sitemap\SitemapHandler;
-use CorianderCore\Utils\DirectoryHandler;
+use CorianderCore\Core\Sitemap\SitemapHandler;
+use CorianderCore\Core\Utils\DirectoryHandler;
 use ReflectionClass;
 use SimpleXMLElement;
 

--- a/composer.json
+++ b/composer.json
@@ -18,6 +18,12 @@
     "require-dev": {
         "phpunit/phpunit": "^11.3"
     },
+    "autoload": {
+        "psr-4": {
+            "CorianderCore\\Core\\": "CorianderCore/core/",
+            "CorianderCore\\Modules\\": "CorianderCore/modules/"
+        }
+    },
     "autoload-dev": {
         "psr-4": {
             "CorianderCore\\Tests\\": "CorianderCore/tests/"

--- a/public/public_views/home/index.php
+++ b/public/public_views/home/index.php
@@ -1,6 +1,6 @@
 <?php
 
-use CorianderCore\Image\ImageHandler;
+use CorianderCore\Core\Image\ImageHandler;
 ?>
 <h1 class="mt-6 md:mt-16 font-concert-one text-2xl sm:text-4xl hsm:text-5xl md:text-6xl text-dark-green dark:text-peach tracking-1 text-center">
     🎉 Installation Successful! 🎉


### PR DESCRIPTION
## Summary
- enforce PSR-4 namespaces across core and tests
- replace custom autoloader with namespace→path map
- expose PSR-4 mappings in composer.json and views

## Testing
- `composer test`

## Issue
https://github.com/CorianderPHP/CorianderPHP/issues/63