### PR TITLE
Centralize controller name formatting

### DIFF
--- a/CorianderCore/core/Console/Commands/Benchmark/BenchmarkRouter.php
+++ b/CorianderCore/core/Console/Commands/Benchmark/BenchmarkRouter.php
@@ -5,6 +5,7 @@ namespace CorianderCore\Core\Console\Commands\Benchmark;
 use CorianderCore\Core\Benchmark\BenchmarkHandler;
 use CorianderCore\Core\Console\ConsoleOutput;
 use CorianderCore\Core\Router\Router;
+use CorianderCore\Core\Router\NameFormatter;
 
 /**
  * BenchmarkRouter handles benchmarking related to routing performance.
@@ -91,7 +92,7 @@ class BenchmarkRouter
         }
 
         // Check for a controller matching the route name
-        $controllerName = $router->formatControllerName($route) . 'Controller';
+        $controllerName = NameFormatter::toPascalCase($route) . 'Controller';
         $controllerClass = 'Controllers\\' . $controllerName;
 
         if (class_exists($controllerClass)) {

--- a/CorianderCore/core/Console/Commands/Make/Controller/MakeController.php
+++ b/CorianderCore/core/Console/Commands/Make/Controller/MakeController.php
@@ -3,6 +3,7 @@
 namespace CorianderCore\Core\Console\Commands\Make\Controller;
 
 use CorianderCore\Core\Console\ConsoleOutput;
+use CorianderCore\Core\Router\NameFormatter;
 
 /**
  * The MakeController class is responsible for generating new controller files
@@ -62,7 +63,7 @@ class MakeController
         $controllerNameRaw = $args[0];
         $isApi = in_array('--api', $args, true);
 
-        $controllerName = $this->formatControllerName($controllerNameRaw);
+        $controllerName = NameFormatter::toPascalCase($controllerNameRaw);
         if (!preg_match('/Controller$/', $controllerName)) {
             $controllerName .= 'Controller';
         }
@@ -85,21 +86,6 @@ class MakeController
         } catch (\Exception $e) {
             ConsoleOutput::print("&4[Error]&7 Failed to create controller: " . $e->getMessage());
         }
-    }
-
-    /**
-     * Formats the controller name to PascalCase.
-     * 
-     * This method converts a controller name like 'admin_user', 'admin-user', or 'adminUser'
-     * into 'AdminUser' to ensure proper naming conventions.
-     *
-     * @param string $name The original controller name.
-     * @return string The formatted controller name in PascalCase.
-     */
-    protected function formatControllerName(string $name): string
-    {
-        // Convert kebab-case or snake_case to PascalCase.
-        return str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $name)));
     }
 
     /**

--- a/CorianderCore/core/Router/ApiControllerHandler.php
+++ b/CorianderCore/core/Router/ApiControllerHandler.php
@@ -2,6 +2,8 @@
 
 namespace CorianderCore\Core\Router;
 
+use CorianderCore\Core\Router\NameFormatter;
+
 /**
  * Handles dispatching to API controllers based on RESTful methods and subpaths.
  */
@@ -22,7 +24,7 @@ class ApiControllerHandler
         $segments = explode('/', $path);
         array_shift($segments); // Remove 'api'
 
-        $controllerName = $this->formatControllerName($segments[0] ?? '');
+        $controllerName = NameFormatter::toPascalCase($segments[0] ?? '');
         $controllerClass = 'ApiControllers\\' . $controllerName . 'Controller';
 
         if (!class_exists($controllerClass)) {
@@ -47,16 +49,5 @@ class ApiControllerHandler
 
         call_user_func_array([$controller, $action], $params);
         return true;
-    }
-
-    /**
-     * Convert a URI segment into a PascalCase controller name.
-     *
-     * @param string $name The raw controller segment.
-     * @return string PascalCase formatted controller name.
-     */
-    private function formatControllerName(string $name): string
-    {
-        return str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $name)));
     }
 }

--- a/CorianderCore/core/Router/Router.php
+++ b/CorianderCore/core/Router/Router.php
@@ -75,14 +75,4 @@ class Router
         $this->dispatcher->dispatch($_SERVER['REQUEST_URI'], $_SERVER['REQUEST_METHOD']);
     }
     
-    /**
-     * Convert a raw route name to PascalCase controller name.
-     *
-     * @param string $name The raw controller segment (e.g., 'user-profile').
-     * @return string PascalCase format (e.g., 'UserProfile').
-     */
-    public function formatControllerName(string $name): string
-    {
-        return str_replace(' ', '', ucwords(str_replace(['-', '_'], ' ', $name)));
-    }
 }


### PR DESCRIPTION
## Summary
- remove Router::formatControllerName in favor of NameFormatter
- switch ApiControllerHandler, BenchmarkRouter, and MakeController to NameFormatter::toPascalCase

## Testing
- `composer test`