### PR TITLE
Load project routes from routes file

### DIFF
--- a/CorianderCore/core/Router/RouteDispatcher.php
+++ b/CorianderCore/core/Router/RouteDispatcher.php
@@ -34,9 +34,14 @@ class RouteDispatcher
 
         defined('REQUESTED_VIEW') || define('REQUESTED_VIEW', $path);
 
-        if ($callback = $this->registry->get($path)) {
-            call_user_func($callback);
-            return;
+        $method = strtoupper($method);
+
+        foreach ($this->registry->getRoutes() as [$routeMethod, $pattern, $callback]) {
+            if ($routeMethod === $method && preg_match($pattern, $path, $matches)) {
+                array_shift($matches);
+                call_user_func_array($callback, $matches);
+                return;
+            }
         }
 
         if (str_starts_with($path, 'api/')) {

--- a/CorianderCore/core/Router/RouteRegistry.php
+++ b/CorianderCore/core/Router/RouteRegistry.php
@@ -8,7 +8,7 @@ namespace CorianderCore\Core\Router;
 class RouteRegistry
 {
     /**
-     * @var array<string, callable>
+     * @var array<int, array{0:string,1:string,2:callable}>
      */
     private array $routes = [];
 
@@ -20,24 +20,24 @@ class RouteRegistry
     /**
      * Register a new route and its handler.
      *
-     * @param string   $route    Path to register.
+     * @param string   $method  HTTP method for the route.
+     * @param string   $pattern Regex pattern for the route.
      * @param callable $callback Callback executed for the route.
      * @return void
      */
-    public function add(string $route, callable $callback): void
+    public function add(string $method, string $pattern, callable $callback): void
     {
-        $this->routes[$route] = $callback;
+        $this->routes[] = [$method, $pattern, $callback];
     }
 
     /**
-     * Retrieve the callback for a registered route.
+     * Retrieve all registered routes.
      *
-     * @param string $route Path to look up.
-     * @return callable|null The matching callback or null if not found.
+     * @return array<int, array{0:string,1:string,2:callable}>
      */
-    public function get(string $route): ?callable
+    public function getRoutes(): array
     {
-        return $this->routes[$route] ?? null;
+        return $this->routes;
     }
 
     /**

--- a/CorianderCore/core/Router/Router.php
+++ b/CorianderCore/core/Router/Router.php
@@ -43,13 +43,19 @@ class Router
     /**
      * Register a custom route handler.
      *
-     * @param string   $route    URI path to match.
+     * @param string   $method  HTTP method for the route.
+     * @param string   $pattern URI pattern, e.g. '/user/{id}'.
      * @param callable $callback Callback executed when the route is matched.
      * @return void
      */
-    public function add(string $route, callable $callback): void
+    public function add(string $method, string $pattern, callable $callback): void
     {
-        $this->registry->add($route, $callback);
+        $pattern = trim($pattern, '/');
+        $regex = preg_quote($pattern, '#');
+        $regex = preg_replace('#\\\{([^/]+)\\\}#', '([^/]+)', $regex);
+        $regex = '#^' . $regex . '$#';
+
+        $this->registry->add(strtoupper($method), $regex, $callback);
     }
 
     /**

--- a/public/index.php
+++ b/public/index.php
@@ -15,13 +15,13 @@ if (file_exists(PROJECT_ROOT . '/vendor/autoload.php')) {
     require_once PROJECT_ROOT . '/vendor/autoload.php';
 }
 
-use CorianderCore\Router\Router;
+use CorianderCore\Core\Router\Router;
 
 // Initialize the router
 $router = Router::getInstance();
 
 // Custom 404 handler
-$router->setNotFound(function () {
+$notFound = function () {
     $notFoundView = "notfound";
 
     $metaDataFile = PROJECT_ROOT . '/public/public_views/' . $notFoundView . '/metadata.php';
@@ -34,17 +34,14 @@ $router->setNotFound(function () {
     require_once PROJECT_ROOT . '/public/public_views/header.php';
     require_once PROJECT_ROOT . '/public/public_views/' . $notFoundView . '/index.php';
     require_once PROJECT_ROOT . '/public/public_views/footer.php';
-});
+};
+$router->setNotFound($notFound);
 
-// Route for handling sitemap.xml requests
-$router->add('sitemap.xml', function () use ($router) {
-    $sitemapPath = PROJECT_ROOT . '/public/sitemap.php';
-    if (!file_exists($sitemapPath)) {
-        $router->handleNotFound();
-        return;
-    }
-    require_once $sitemapPath;
-});
+// Load project-specific routes if available
+$routesFile = __DIR__ . '/routes.php';
+if (file_exists($routesFile)) {
+    require $routesFile;
+}
 
 // Dispatch the request to the correct view or controller
 $router->dispatch();

--- a/public/routes.php
+++ b/public/routes.php
@@ -1,0 +1,20 @@
+<?php
+
+// Register custom routes here. This file is included by index.php and
+// has access to the `$router` and `$notFound` variables.
+
+// Example dynamic route: /user/42 -> "User ID: 42"
+// $router->add('GET', 'user/{id}', function (string $id) {
+//     echo "User ID: {$id}";
+// });
+
+// Route for handling sitemap.xml requests
+$router->add('GET', 'sitemap.xml', function () use ($notFound) {
+    $sitemapPath = PROJECT_ROOT . '/public/sitemap.php';
+    if (!file_exists($sitemapPath)) {
+        $notFound();
+        return;
+    }
+    require_once $sitemapPath;
+});
+


### PR DESCRIPTION
## Summary
- allow `public/index.php` to automatically load routes from a colocated `routes.php` file
- expand router to support HTTP-method-aware regex patterns
- include a commented example of dynamic URL parameters in `public/routes.php`

## Testing
- `composer install`
- `composer test`