### PR TITLE
Add CSRF protection and router middleware hooks

### DIFF
--- a/CorianderCore/core/Console/Commands/Make/Controller/templates/ApiController.php
+++ b/CorianderCore/core/Console/Commands/Make/Controller/templates/ApiController.php
@@ -2,6 +2,8 @@
 
 namespace CorianderCore\Core\Console\Commands\Make\Controller\templates;
 
+use CorianderCore\Core\Security\Csrf;
+
 /**
  * Class {{controllerName}}
  *
@@ -24,6 +26,12 @@ class {{controllerName}}
     public function post(): void
     {
         $input = json_decode(file_get_contents('php://input'), true);
+        if (!Csrf::validate($input['csrf_token'] ?? null)) {
+            http_response_code(403);
+            header('Content-Type: application/json');
+            echo json_encode(['error' => 'Invalid CSRF token']);
+            return;
+        }
         header('Content-Type: application/json');
         echo json_encode(['message' => 'Data received', 'data' => $input]);
     }

--- a/CorianderCore/core/Console/Commands/Make/Controller/templates/WebController.php
+++ b/CorianderCore/core/Console/Commands/Make/Controller/templates/WebController.php
@@ -3,6 +3,7 @@
 namespace CorianderCore\Core\Console\Commands\Make\Controller\templates;
 
 use CorianderCore\Core\Router\ViewRenderer;
+use CorianderCore\Core\Security\Csrf;
 
 /**
  * Class {{controllerName}}
@@ -60,6 +61,12 @@ class {{controllerName}}
      */
     public function store()
     {
+        if (!Csrf::validateRequest()) {
+            http_response_code(403);
+            echo 'Invalid CSRF token';
+            return;
+        }
+
         // Example: Process form submission data
         // $formData = $_POST;
         // Validation and processing logic here

--- a/CorianderCore/core/Console/Commands/Make/View/templates/view.php
+++ b/CorianderCore/core/Console/Commands/Make/View/templates/view.php
@@ -2,4 +2,8 @@
 <section>
     <h1>{{viewName}}</h1>
     <p>This is the {{viewName}} view.</p>
+    <form method="POST">
+        <?= \CorianderCore\Core\Security\Csrf::input() ?>
+        <!-- Add your form fields here -->
+    </form>
 </section>

--- a/CorianderCore/core/Security/Csrf.php
+++ b/CorianderCore/core/Security/Csrf.php
@@ -1,0 +1,94 @@
+<?php
+
+namespace CorianderCore\Core\Security;
+
+/**
+ * Handles generation, storage, and validation of CSRF tokens.
+ *
+ * Workflow:
+ * - Tokens are generated lazily and stored in the active session.
+ * - Forms include the token via {@see Csrf::input()} to embed a hidden field.
+ * - Incoming POST requests are validated against the stored token.
+ */
+class Csrf
+{
+    private const SESSION_KEY = '_csrf_token';
+
+    /**
+     * Generate or retrieve the current CSRF token.
+     *
+     * @return string The CSRF token stored in session.
+     */
+    public static function token(): string
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        if (empty($_SESSION[self::SESSION_KEY])) {
+            $_SESSION[self::SESSION_KEY] = bin2hex(random_bytes(32));
+        }
+
+        return $_SESSION[self::SESSION_KEY];
+    }
+
+    /**
+     * Render a hidden input element containing the CSRF token.
+     *
+     * @return string HTML markup for the hidden token field.
+     */
+    public static function input(): string
+    {
+        $token = htmlspecialchars(self::token(), ENT_QUOTES, 'UTF-8');
+        return '<input type="hidden" name="csrf_token" value="' . $token . '">';
+    }
+
+    /**
+     * Validate the supplied token against the session value.
+     *
+     * @param string|null $token Token supplied by the client.
+     * @return bool True when the token matches the session value.
+     */
+    public static function validate(?string $token): bool
+    {
+        if (session_status() !== PHP_SESSION_ACTIVE) {
+            session_start();
+        }
+
+        $sessionToken = $_SESSION[self::SESSION_KEY] ?? '';
+        return $sessionToken !== '' && $token !== null && hash_equals($sessionToken, $token);
+    }
+
+    /**
+     * Validate the CSRF token from the current POST request.
+     *
+     * @return bool True when the request token is valid.
+     */
+    public static function validateRequest(): bool
+    {
+        $token = $_POST['csrf_token'] ?? null;
+        return self::validate($token);
+    }
+
+    /**
+     * Middleware-style hook for Router::before().
+     *
+     * @param string $uri    Requested URI.
+     * @param string $method HTTP method.
+     * @return bool False when validation fails to halt dispatch.
+     */
+    public static function verify(string $uri, string $method): bool
+    {
+        if (strtoupper($method) !== 'POST') {
+            return true;
+        }
+
+        if (!self::validateRequest()) {
+            http_response_code(403);
+            echo 'Invalid CSRF token';
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -16,9 +16,11 @@ if (file_exists(PROJECT_ROOT . '/vendor/autoload.php')) {
 }
 
 use CorianderCore\Core\Router\Router;
+use CorianderCore\Core\Security\Csrf;
 
 // Initialize the router
 $router = Router::getInstance();
+$router->before([Csrf::class, 'verify']);
 
 // Custom 404 handler
 $notFound = function () {

--- a/readme.md
+++ b/readme.md
@@ -114,6 +114,25 @@ You can customize the generated `sitemap.php` file to fit your needs by adding d
 
 ---
 
+## CSRF Protection
+
+CorianderPHP ships with a simple token-based CSRF guard. The router registers a
+middleware that validates tokens on incoming `POST` requests. To include the
+token in your forms, output the helper inside the `<form>` element:
+
+```php
+<form method="POST" action="/submit">
+    <?= \CorianderCore\Core\Security\Csrf::input() ?>
+    <!-- your fields -->
+    <button type="submit">Send</button>
+</form>
+```
+
+Controller templates already verify the token using `Csrf::validateRequest()` or
+`Csrf::validate()` for JSON payloads.
+
+---
+
 ## Development Status
 
 **CorianderPHP** is under active development. Some features, such as WebP image optimization and sitemap creation tools, are currently being implemented. Comprehensive documentation will be provided to assist developers in using and extending the framework.


### PR DESCRIPTION
## Summary
- add CSRF token generation/validation helper
- run CSRF verification through router middleware
- scaffold controllers and views with CSRF support
- document CSRF usage with example form markup

## Testing
- `composer dump-autoload`
- `composer test`