### PR TITLE
Add CSRF, router integration, and API controller handler tests

### DIFF
--- a/CorianderCore/tests/ApiControllerHandlerTest.php
+++ b/CorianderCore/tests/ApiControllerHandlerTest.php
@@ -1,0 +1,126 @@
+<?php
+namespace ApiControllers;
+
+/**
+ * Stub controller for ApiControllerHandler tests.
+ */
+class SampleController
+{
+    /**
+     * Records invoked actions.
+     *
+     * @var array<int, array{0:string,1:array}>
+     */
+    public static array $calls = [];
+
+    /**
+     * Handle GET requests.
+     *
+     * @param mixed ...$params Parameters passed from URI.
+     * @return void
+     */
+    public function get(...$params): void
+    {
+        self::$calls[] = ['get', $params];
+    }
+
+    /**
+     * Handle POST create action.
+     *
+     * @param mixed ...$params Parameters passed from URI.
+     * @return void
+     */
+    public function post_create(...$params): void
+    {
+        self::$calls[] = ['post_create', $params];
+    }
+}
+
+namespace CorianderCore\Tests;
+
+use ApiControllers\SampleController;
+use CorianderCore\Core\Router\Handlers\ApiControllerHandler;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Unit tests for ApiControllerHandler verifying dispatch logic and fallbacks.
+ */
+class ApiControllerHandlerTest extends TestCase
+{
+    /**
+     * Ensure PROJECT_ROOT constant is defined for autoloading.
+     */
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('PROJECT_ROOT')) {
+            define('PROJECT_ROOT', dirname(__DIR__, 2));
+        }
+    }
+
+    /**
+     * Reset stub call history.
+     */
+    protected function setUp(): void
+    {
+        SampleController::$calls = [];
+    }
+
+    /**
+     * Test controller/method resolution for basic GET routes.
+     *
+     * @return void
+     */
+    public function testControllerMethodResolutionForBasicRoutes(): void
+    {
+        $handler = new ApiControllerHandler();
+        $result = $handler->handle('api/sample', 'GET');
+
+        $this->assertTrue($result, 'Handler should dispatch to existing controller.');
+        $this->assertSame([
+            ['get', []],
+        ], SampleController::$calls, 'GET dispatch should call get without parameters.');
+    }
+
+    /**
+     * Check parameter handling from URI and POST sub-action resolution.
+     *
+     * @return void
+     */
+    public function testParamHandlingFromUri(): void
+    {
+        $handler = new ApiControllerHandler();
+        $result = $handler->handle('api/sample/create/42/foo', 'POST');
+
+        $this->assertTrue($result, 'Handler should dispatch to existing controller method.');
+        $this->assertSame([
+            ['post_create', ['42', 'foo']],
+        ], SampleController::$calls, 'POST dispatch should pass URI parameters.');
+    }
+
+    /**
+     * Verify fallback behavior when the controller is missing.
+     *
+     * @return void
+     */
+    public function testFallbackWhenControllerMissing(): void
+    {
+        $handler = new ApiControllerHandler();
+        $result = $handler->handle('api/unknown', 'GET');
+
+        $this->assertFalse($result, 'Handler should return false for missing controller.');
+    }
+
+    /**
+     * Verify fallback behavior when the method is missing.
+     *
+     * @return void
+     */
+    public function testFallbackWhenMethodMissing(): void
+    {
+        $handler = new ApiControllerHandler();
+        $result = $handler->handle('api/sample/unknown', 'GET');
+
+        $this->assertFalse($result, 'Handler should return false for missing method.');
+        $this->assertSame([], SampleController::$calls, 'No method should be invoked when missing.');
+    }
+}

--- a/CorianderCore/tests/CsrfMiddlewareTest.php
+++ b/CorianderCore/tests/CsrfMiddlewareTest.php
@@ -1,0 +1,91 @@
+<?php
+
+namespace CorianderCore\Tests;
+
+use CorianderCore\Core\Security\Csrf;
+use CorianderCore\Core\Security\CsrfMiddleware;
+use Nyholm\Psr7\Response;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\Http\Server\RequestHandlerInterface;
+
+/**
+ * Unit tests for {@see CsrfMiddleware}.
+ *
+ * These tests verify that the middleware correctly bypasses non-POST requests,
+ * rejects invalid tokens, and allows valid tokens to proceed.
+ */
+class CsrfMiddlewareTest extends TestCase
+{
+    /**
+     * Ensure non-POST requests bypass CSRF validation and reach the next handler.
+     */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testBypassesNonPostRequests(): void
+    {
+        $middleware = new CsrfMiddleware();
+        $request = new ServerRequest('GET', '/test');
+        $handler = new class implements RequestHandlerInterface {
+            public bool $called = false;
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->called = true;
+                return new Response(200, [], 'OK');
+            }
+        };
+
+        $response = $middleware->process($request, $handler);
+
+        $this->assertTrue($handler->called);
+        $this->assertSame(200, $response->getStatusCode());
+    }
+
+    /**
+     * Ensure POST requests with an invalid token are rejected with a 403 status code.
+     */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testRejectsInvalidToken(): void
+    {
+        $middleware = new CsrfMiddleware();
+        $request = (new ServerRequest('POST', '/test'))
+            ->withParsedBody(['csrf_token' => 'invalid']);
+        $handler = new class implements RequestHandlerInterface {
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                return new Response(200, [], 'OK');
+            }
+        };
+
+        $response = $middleware->process($request, $handler);
+
+        $this->assertSame(403, $response->getStatusCode());
+        $this->assertSame('Invalid CSRF token', (string) $response->getBody());
+    }
+
+    /**
+     * Ensure POST requests with a valid token are allowed through the middleware.
+     */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testAllowsValidToken(): void
+    {
+        $token = Csrf::token();
+        $middleware = new CsrfMiddleware();
+        $request = (new ServerRequest('POST', '/test'))
+            ->withParsedBody(['csrf_token' => $token]);
+        $handler = new class implements RequestHandlerInterface {
+            public bool $called = false;
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->called = true;
+                return new Response(200, [], 'OK');
+            }
+        };
+
+        $response = $middleware->process($request, $handler);
+
+        $this->assertTrue($handler->called);
+        $this->assertSame(200, $response->getStatusCode());
+    }
+}

--- a/CorianderCore/tests/RouterIntegrationTest.php
+++ b/CorianderCore/tests/RouterIntegrationTest.php
@@ -1,0 +1,139 @@
+<?php
+
+namespace CorianderCore\Tests;
+
+use CorianderCore\Core\Router\Router;
+use CorianderCore\Core\Security\Csrf;
+use CorianderCore\Core\Security\CsrfMiddleware;
+use Nyholm\Psr7\Response;
+use Nyholm\Psr7\ServerRequest;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * Integration tests exercising the full Router pipeline including middleware,
+ * complex routes, and error handling.
+ */
+class RouterIntegrationTest extends TestCase
+{
+    private Router $router;
+    private bool $srcCreated = false;
+    private bool $controllersCreated = false;
+
+    public static function setUpBeforeClass(): void
+    {
+        if (!defined('PROJECT_ROOT')) {
+            define('PROJECT_ROOT', dirname(__DIR__, 2));
+        }
+    }
+
+    protected function setUp(): void
+    {
+        $this->router = Router::getInstance();
+
+        if (!is_dir(PROJECT_ROOT . '/src')) {
+            mkdir(PROJECT_ROOT . '/src', 0777, true);
+            $this->srcCreated = true;
+        }
+
+        if (!is_dir(PROJECT_ROOT . '/src/Controllers')) {
+            mkdir(PROJECT_ROOT . '/src/Controllers', 0777, true);
+            $this->controllersCreated = true;
+        }
+    }
+
+    protected function tearDown(): void
+    {
+        unset($this->router);
+
+        if ($this->controllersCreated) {
+            $this->deleteDirectory(PROJECT_ROOT . '/src/Controllers');
+        }
+
+        if ($this->srcCreated) {
+            $this->deleteDirectory(PROJECT_ROOT . '/src');
+        }
+    }
+
+    /**
+     * Recursively delete a directory created during the test lifecycle.
+     *
+     * @param string $path Directory path to remove.
+     * @return void
+     */
+    private function deleteDirectory(string $path): void
+    {
+        if (!is_dir($path)) {
+            return;
+        }
+
+        foreach (array_diff(scandir($path), ['.', '..']) as $item) {
+            $itemPath = $path . '/' . $item;
+            is_dir($itemPath) ? $this->deleteDirectory($itemPath) : unlink($itemPath);
+        }
+
+        rmdir($path);
+    }
+
+    /**
+     * Ensure the router returns a 404 response when no route matches.
+     */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testDefaultNotFoundResponse(): void
+    {
+        $request = new ServerRequest('GET', '/missing');
+        $response = $this->router->dispatch($request);
+
+        $this->assertSame(404, $response->getStatusCode());
+        $this->assertSame('404 Not Found', (string) $response->getBody());
+    }
+
+    /**
+     * Verify that complex routes with multiple parameters are dispatched correctly.
+     */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testComplexRouteParameterDispatch(): void
+    {
+        $this->router->add('GET', '/blog/{year}/{month}/{slug}', function (string $year, string $month, string $slug) {
+            return new Response(200, [], "$year-$month-$slug");
+        });
+
+        $request = new ServerRequest('GET', '/blog/2024/01/new-year');
+        $response = $this->router->dispatch($request);
+
+        $this->assertSame('2024-01-new-year', (string) $response->getBody());
+    }
+
+    /**
+     * Integration test verifying CSRF middleware rejection of invalid tokens.
+     */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testCsrfMiddlewareRejectsInvalidToken(): void
+    {
+        $this->router->addMiddleware(new CsrfMiddleware());
+        $this->router->add('POST', '/submit', fn () => new Response(200, [], 'OK'));
+
+        $request = (new ServerRequest('POST', '/submit'))
+            ->withParsedBody(['csrf_token' => 'bad']);
+        $response = $this->router->dispatch($request);
+
+        $this->assertSame(403, $response->getStatusCode());
+    }
+
+    /**
+     * Integration test verifying CSRF middleware acceptance of valid tokens.
+     */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testCsrfMiddlewareAllowsValidToken(): void
+    {
+        $token = Csrf::token();
+        $this->router->addMiddleware(new CsrfMiddleware());
+        $this->router->add('POST', '/submit', fn () => new Response(200, [], 'OK'));
+
+        $request = (new ServerRequest('POST', '/submit'))
+            ->withParsedBody(['csrf_token' => $token]);
+        $response = $this->router->dispatch($request);
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('OK', (string) $response->getBody());
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for CsrfMiddleware
- add integration tests covering Router error handling, CSRF, and complex routes
- add ApiControllerHandler unit tests for dispatching and fallback behavior

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68adafafdf188323b1f7571e04360668