### PR TITLE
♻️ refactor: enforce strict typing across core

### DIFF
--- a/CorianderCore/core/Benchmark/BenchmarkHandler.php
+++ b/CorianderCore/core/Benchmark/BenchmarkHandler.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+
+/*
+ * BenchmarkHandler captures execution metrics to evaluate performance of
+ * framework components such as memory, CPU and initialization time.
+ */
 
 namespace CorianderCore\Core\Benchmark;
 
@@ -8,22 +14,56 @@ namespace CorianderCore\Core\Benchmark;
  */
 class BenchmarkHandler
 {
-    protected $startTime;
-    protected $endTime;
-    protected $initialMemory;
-    protected $cpuStart;
-    protected $cpuEnd;
+    /**
+     * @var float Start time of the benchmark.
+     */
+    protected float $startTime = 0.0;
 
-    protected $lowestMemoryUsage;
-    protected $highestMemoryUsage;
-    protected $lowestCpuUsage;
-    protected $highestCpuUsage;
+    /**
+     * @var float End time of the benchmark.
+     */
+    protected float $endTime = 0.0;
+
+    /**
+     * @var int Initial memory usage in bytes.
+     */
+    protected int $initialMemory = 0;
+
+    /**
+     * @var float CPU usage at start.
+     */
+    protected float $cpuStart = 0.0;
+
+    /**
+     * @var float CPU usage at end.
+     */
+    protected float $cpuEnd = 0.0;
+
+    /**
+     * @var int Lowest memory usage recorded.
+     */
+    protected int $lowestMemoryUsage = 0;
+
+    /**
+     * @var int Highest memory usage recorded.
+     */
+    protected int $highestMemoryUsage = 0;
+
+    /**
+     * @var float Lowest CPU usage recorded.
+     */
+    protected float $lowestCpuUsage = 0.0;
+
+    /**
+     * @var float Highest CPU usage recorded.
+     */
+    protected float $highestCpuUsage = 0.0;
 
     /**
      * Initializes the BenchmarkHandler by recording the start time, memory usage, and CPU usage.
      * Also initializes the peak and low values for memory and CPU usage.
      */
-    public function start()
+    public function start(): void
     {
         $this->startTime = microtime(true);
         $this->initialMemory = memory_get_usage();
@@ -41,7 +81,7 @@ class BenchmarkHandler
      * Stops the benchmark by recording the end time and CPU usage.
      * Also updates the peak and low values for memory and CPU usage.
      */
-    public function stop()
+    public function stop(): void
     {
         $this->endTime = microtime(true);
         $this->cpuEnd = $this->getCpuUsage();
@@ -58,7 +98,8 @@ class BenchmarkHandler
      */
     public function getInitializationTime(): float
     {
-        return $this->endTime - $this->startTime;
+        $end = $this->endTime ?: microtime(true);
+        return $end - $this->startTime;
     }
 
     /**
@@ -180,7 +221,7 @@ class BenchmarkHandler
     /**
      * Tracks the lowest and highest memory usage during the benchmarking period.
      */
-    public function updateMemoryPeak()
+    public function updateMemoryPeak(): void
     {
         $currentMemoryUsage = memory_get_usage();
 
@@ -196,7 +237,7 @@ class BenchmarkHandler
     /**
      * Tracks the lowest and highest CPU usage during the benchmarking period.
      */
-    public function updateCpuPeak()
+    public function updateCpuPeak(): void
     {
         $currentCpuUsage = $this->getCpuUsage();
 

--- a/CorianderCore/core/Console/CommandHandler.php
+++ b/CorianderCore/core/Console/CommandHandler.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+
+/*
+ * CommandHandler orchestrates CLI command execution by mapping command names
+ * to handler classes and delegating argument processing to each command.
+ */
 
 namespace CorianderCore\Core\Console;
 
@@ -13,9 +19,9 @@ class CommandHandler
     /**
      * Available commands and their corresponding handler classes.
      *
-     * @var array
+     * @var array<string, class-string>
      */
-    protected $commands = [
+    protected array $commands = [
         'hello' => \CorianderCore\Core\Console\Commands\Hello::class,
         'nodejs' => \CorianderCore\Core\Console\Commands\NodeJS::class,
         'make' => \CorianderCore\Core\Console\Commands\Make::class,
@@ -29,8 +35,9 @@ class CommandHandler
      * @param string $command The command name to execute
      * @param array $args The arguments passed to the command
      * @throws \Exception If the command does not exist or the command class lacks an 'execute' method.
+     * @return void
      */
-    public function handle(string $command, array $args)
+    public function handle(string $command, array $args): void
     {
         ConsoleOutput::hr();
         // Check if the command contains a colon (e.g., make:view)
@@ -82,8 +89,10 @@ class CommandHandler
 
     /**
      * Lists all available commands, including 'help'.
+     *
+     * @return void
      */
-    protected function listCommands()
+    protected function listCommands(): void
     {
         ConsoleOutput::print("Available commands:");
 

--- a/CorianderCore/core/Console/Commands/Benchmark.php
+++ b/CorianderCore/core/Console/Commands/Benchmark.php
@@ -1,8 +1,15 @@
 <?php
+declare(strict_types=1);
+
+/*
+ * Benchmark command delegates subcommands to specific handlers allowing
+ * measurement of various framework components such as the router.
+ */
 
 namespace CorianderCore\Core\Console\Commands;
 
 use CorianderCore\Core\Console\ConsoleOutput;
+use CorianderCore\Core\Console\Commands\Benchmark\BenchmarkRouter;
 
 /**
  * Benchmark is responsible for handling benchmark-related commands such as 'benchmark:router'.
@@ -15,24 +22,24 @@ class Benchmark
      * List of valid subcommands that the 'benchmark' command supports.
      * Each subcommand corresponds to a specific resource benchmark action (e.g., router).
      *
-     * @var array
+     * @var string[]
      */
-    protected $validSubcommands = [
+    protected array $validSubcommands = [
         'router'
     ];
 
     /**
      * Instances of the subcommand handlers (e.g., BenchmarkRouter).
      *
-     * @var object|null
+     * @var BenchmarkRouter
      */
-    protected $benchmarkRouterInstance;
+    protected BenchmarkRouter $benchmarkRouterInstance;
     /**
      * Constructor for the Benchmark class.
      */
     public function __construct()
     {
-        $this->benchmarkRouterInstance = new \CorianderCore\Core\Console\Commands\Benchmark\BenchmarkRouter();
+        $this->benchmarkRouterInstance = new BenchmarkRouter();
     }
 
     /**
@@ -46,8 +53,9 @@ class Benchmark
      * - 'php coriander benchmark:router' will benchmark the router performance.
      *
      * @param array $args The arguments passed to the benchmark command, including the subcommand and resource name.
+     * @return void
      */
-    public function execute(array $args)
+    public function execute(array $args): void
     {
         // Ensure the command has at least one argument (the subcommand)
         if (empty($args) || !isset($args[0])) {
@@ -88,8 +96,9 @@ class Benchmark
      * This method initiates the router benchmarking process.
      *
      * @param array $args The arguments for benchmarking the router.
+     * @return void
      */
-    protected function benchmarkRouter(array $args)
+    protected function benchmarkRouter(array $args): void
     {
         // Delegate the router benchmarking task to the BenchmarkRouter class
         $this->benchmarkRouterInstance->execute($args);
@@ -97,8 +106,10 @@ class Benchmark
 
     /**
      * Lists all available benchmark: commands.
+     *
+     * @return void
      */
-    protected function listCommands()
+    protected function listCommands(): void
     {
         ConsoleOutput::print("Available benchmark commands:");
 

--- a/CorianderCore/core/Console/Commands/Benchmark/BenchmarkRouter.php
+++ b/CorianderCore/core/Console/Commands/Benchmark/BenchmarkRouter.php
@@ -1,4 +1,9 @@
 <?php
+declare(strict_types=1);
+
+/*
+ * BenchmarkRouter simulates routing requests to measure dispatcher performance.
+ */
 
 namespace CorianderCore\Core\Console\Commands\Benchmark;
 
@@ -18,8 +23,9 @@ class BenchmarkRouter
      * Executes the benchmark process for the router.
      *
      * @param array $args The arguments passed to the benchmark:router command (e.g., route name, duration).
+     * @return void
      */
-    public function execute(array $args)
+    public function execute(array $args): void
     {
         // Default route to 'home' if not specified
         $route = $args[0] ?? 'home';

--- a/CorianderCore/core/Console/Commands/Cache.php
+++ b/CorianderCore/core/Console/Commands/Cache.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands;
 

--- a/CorianderCore/core/Console/Commands/Hello.php
+++ b/CorianderCore/core/Console/Commands/Hello.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+
+/*
+ * Hello command outputs a friendly greeting used primarily for testing the
+ * console infrastructure.
+ */
 
 namespace CorianderCore\Core\Console\Commands;
 
@@ -12,8 +18,10 @@ class Hello
      * This method outputs a friendly greeting message to the user when the
      * 'hello' command is invoked through the CommandHandler. It serves as 
      * a basic example of a command that can be executed in the console.
+     *
+     * @return void
      */
-    public function execute()
+    public function execute(): void
     {
         ConsoleOutput::print("Hi! I'm &2Coriander&7, how can I help you?");
     }

--- a/CorianderCore/core/Console/Commands/Make.php
+++ b/CorianderCore/core/Console/Commands/Make.php
@@ -1,8 +1,19 @@
 <?php
+declare(strict_types=1);
+
+/*
+ * Make command coordinates resource-generation subcommands such as
+ * views, controllers, databases and sitemaps by delegating to their
+ * respective handlers.
+ */
 
 namespace CorianderCore\Core\Console\Commands;
 
 use CorianderCore\Core\Console\ConsoleOutput;
+use CorianderCore\Core\Console\Commands\Make\View\MakeView;
+use CorianderCore\Core\Console\Commands\Make\Controller\MakeController;
+use CorianderCore\Core\Console\Commands\Make\Database\MakeDatabase;
+use CorianderCore\Core\Console\Commands\Make\Sitemap\MakeSitemap;
 
 /**
  * Class responsible for handling make-related commands such as 'make:view', 'make:controller', and 'make:database'.
@@ -15,9 +26,9 @@ class Make
      * List of valid subcommands that the 'make' command supports.
      * Each subcommand corresponds to a specific resource creation action (e.g., view, controller, database).
      *
-     * @var array
+     * @var string[]
      */
-    protected $validSubcommands = [
+    protected array $validSubcommands = [
         'view',
         'controller',
         'database',
@@ -27,12 +38,24 @@ class Make
     /**
      * Instances of the subcommand handlers (e.g., MakeView, MakeController, MakeDatabase).
      *
-     * @var object|null
+     * @var MakeView
      */
-    protected $makeViewInstance;
-    protected $makeControllerInstance;
-    protected $makeDatabaseInstance;
-    protected $makeSitemapInstance;
+    protected MakeView $makeViewInstance;
+
+    /**
+     * @var MakeController
+     */
+    protected MakeController $makeControllerInstance;
+
+    /**
+     * @var MakeDatabase
+     */
+    protected MakeDatabase $makeDatabaseInstance;
+
+    /**
+     * @var MakeSitemap
+     */
+    protected MakeSitemap $makeSitemapInstance;
 
     /**
      * Constructor for the Make class.
@@ -60,7 +83,7 @@ class Make
      *
      * @param array $args The arguments passed to the make command, including the subcommand and resource name.
      */
-    public function execute(array $args)
+    public function execute(array $args): void
     {
         // Ensure the command has at least one argument (the subcommand)
         if (empty($args) || !isset($args[0])) {
@@ -115,7 +138,7 @@ class Make
      *
      * @param array $args The arguments for creating the view (e.g., the name of the view).
      */
-    protected function makeView(array $args)
+    protected function makeView(array $args): void
     {
         // Ensure a view name is provided
         if (empty($args)) {
@@ -135,7 +158,7 @@ class Make
      *
      * @param array $args The arguments for creating the controller (e.g., the name of the controller).
      */
-    protected function makeController(array $args)
+    protected function makeController(array $args): void
     {
         // Ensure a controller name is provided
         if (empty($args)) {
@@ -154,7 +177,7 @@ class Make
      *
      * @param array $args The arguments for creating or configuring the database.
      */
-    protected function makeDatabase(array $args)
+    protected function makeDatabase(array $args): void
     {
         // Delegate the database creation task to the MakeDatabase class
         $this->makeDatabaseInstance->execute($args);
@@ -167,7 +190,7 @@ class Make
      *
      * @param array $args The arguments for creating or updating the sitemap.
      */
-    protected function makeSitemap(array $args)
+    protected function makeSitemap(array $args): void
     {
         // Delegate the sitemap creation task to the MakeSitemap class
         $this->makeSitemapInstance->execute($args);
@@ -176,7 +199,7 @@ class Make
     /**
      * Lists all available make: commands.
      */
-    protected function listCommands()
+    protected function listCommands(): void
     {
         ConsoleOutput::print("Available make commands:");
 

--- a/CorianderCore/core/Console/Commands/Make/Controller/MakeController.php
+++ b/CorianderCore/core/Console/Commands/Make/Controller/MakeController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands\Make\Controller;
 
@@ -13,14 +14,14 @@ use CorianderCore\Core\Router\NameFormatter;
 class MakeController
 {
     /**
-     * @var string $templatesPath The path to the directory containing controller templates.
+     * @var string The path to the directory containing controller templates.
      */
-    protected $templatesPath;
+    protected string $templatesPath;
 
     /**
-     * @var string $basePath The base path where controllers will be created.
+     * @var string The base path where controllers will be created.
      */
-    protected $basePath;
+    protected string $basePath;
 
     /**
      * Constructor for the MakeController class.
@@ -53,7 +54,7 @@ class MakeController
      *
      * @param array $args The arguments passed to the command, where the first argument is the controller name.
      */
-    public function execute(array $args)
+    public function execute(array $args): void
     {
         if (empty($args)) {
             ConsoleOutput::print("&4[Error]&7 Please specify a controller name.");
@@ -110,7 +111,7 @@ class MakeController
      *
      * @param string $directory The path to the directory.
      */
-    protected function ensureDirectoryExists(string $directory)
+    protected function ensureDirectoryExists(string $directory): void
     {
         if (!is_dir($directory)) {
             if (!mkdir($directory, 0755, true)) {
@@ -146,7 +147,7 @@ class MakeController
      * @param string $kebabCaseName The kebab-case version of the controller name for view paths.
      * @throws \Exception If the template file cannot be written.
      */
-    protected function createFileFromTemplate(string $templateFile, string $destinationFile, string $controllerName, string $kebabCaseName)
+    protected function createFileFromTemplate(string $templateFile, string $destinationFile, string $controllerName, string $kebabCaseName): void
     {
         // Define the full path to the template file.
         $templatePath = $this->templatesPath . '/' . $templateFile;

--- a/CorianderCore/core/Console/Commands/Make/Controller/templates/ApiController.php
+++ b/CorianderCore/core/Console/Commands/Make/Controller/templates/ApiController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * Template for generating API controllers.

--- a/CorianderCore/core/Console/Commands/Make/Controller/templates/WebController.php
+++ b/CorianderCore/core/Console/Commands/Make/Controller/templates/WebController.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 /**
  * Template for creating standard web controllers.
@@ -60,7 +61,7 @@ class {{controllerName}}
      * @param mixed $id The ID or slug of the resource to display.
      * @return void
      */
-    public function show($id): void
+    public function show(mixed $id): void
     {
         // Example: Fetch an item from the database
         $data = [

--- a/CorianderCore/core/Console/Commands/Make/Database/MakeDatabase.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/MakeDatabase.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands\Make\Database;
 
@@ -16,14 +17,14 @@ class MakeDatabase
     /**
      * @var PdoDriverService
      */
-    protected $pdoDriverService;
+    protected PdoDriverService $pdoDriverService;
 
     /**
      * Constructor for MakeDatabase.
      *
      * @param PdoDriverService|null $pdoDriverService
      */
-    public function __construct(PdoDriverService $pdoDriverService = null)
+    public function __construct(?PdoDriverService $pdoDriverService = null)
     {
         // If no PdoDriverService is passed, instantiate a default one
         $this->pdoDriverService = $pdoDriverService ?? new PdoDriverService();
@@ -33,7 +34,7 @@ class MakeDatabase
      * Executes the database configuration process based on user input.
      * Checks for the necessary PDO drivers before prompting the user to choose between MySQL and SQLite.
      */
-    public function execute()
+    public function execute(): void
     {
         // Check available PDO drivers and warn if MySQL driver is missing
         $availableDrivers = $this->pdoDriverService->getAvailableDrivers();
@@ -65,7 +66,7 @@ class MakeDatabase
             // SQLite option is always available
             ConsoleOutput::print("&l2&r&7. [&2✓&7] SQLite\n");
 
-            $dbChoice = trim(fgets(STDIN));
+            $dbChoice = trim((string)fgets(STDIN));
             ConsoleOutput::print("\nYou've selected: " . $dbChoice);
             ConsoleOutput::hr();
 

--- a/CorianderCore/core/Console/Commands/Make/Database/MySQL/MakeMySQL.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/MySQL/MakeMySQL.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands\Make\Database\MySQL;
 
@@ -15,12 +16,12 @@ class MakeMySQL
     /**
      * @var string Path to the MySQL templates.
      */
-    protected $templatesPath;
+    protected string $templatesPath;
 
     /**
      * @var string Path to the config folder where the configuration file will be generated.
      */
-    protected $configPath;
+    protected string $configPath;
 
     /**
      * Constructor to initialize paths for templates and configuration files.
@@ -38,23 +39,23 @@ class MakeMySQL
      * Executes the process of creating a MySQL configuration.
      * Prompts the user for MySQL connection details and generates a config file.
      */
-    public function execute()
+    public function execute(): void
     {
         // Ask the user for MySQL connection details
         ConsoleOutput::print("Enter MySQL host:\n");
-        $dbHost = trim(fgets(STDIN));
+        $dbHost = trim((string)fgets(STDIN));
 
         ConsoleOutput::hr();
         ConsoleOutput::print("Enter MySQL database name:\n");
-        $dbName = trim(fgets(STDIN));
+        $dbName = trim((string)fgets(STDIN));
 
         ConsoleOutput::hr();
         ConsoleOutput::print("Enter MySQL user:\n");
-        $dbUser = trim(fgets(STDIN));
+        $dbUser = trim((string)fgets(STDIN));
 
         ConsoleOutput::hr();
         ConsoleOutput::print("Enter MySQL password:\n");
-        $dbPassword = trim(fgets(STDIN));
+        $dbPassword = trim((string)fgets(STDIN));
 
         // Test the MySQL connection
         try {
@@ -67,7 +68,7 @@ class MakeMySQL
             ConsoleOutput::hr();
             ConsoleOutput::print("&4[Error]&7 Connection failed: " . $e->getMessage());
             ConsoleOutput::print("Do you want to proceed anyway? (y/n):\n");
-            $confirmation = strtolower(trim(fgets(STDIN)));
+            $confirmation = strtolower(trim((string)fgets(STDIN)));
             if ($confirmation !== 'y') {
                 ConsoleOutput::print("&e[Warning]&7 Database configuration file not created.");
                 return;
@@ -86,7 +87,7 @@ class MakeMySQL
      * @param string $dbUser The MySQL user.
      * @param string $dbPassword The MySQL password.
      */
-    protected function generateConfig($dbHost, $dbName, $dbUser, $dbPassword)
+    protected function generateConfig(string $dbHost, string $dbName, string $dbUser, string $dbPassword): void
     {
         // Load the MySQL template file
         $templatePath = $this->templatesPath . '/database.php';
@@ -108,7 +109,7 @@ class MakeMySQL
      *
      * @param string $content The content of the configuration file.
      */
-    protected function saveConfig(string $content)
+    protected function saveConfig(string $content): void
     {
         // Ensure the config directory exists
         if (!is_dir($this->configPath)) {

--- a/CorianderCore/core/Console/Commands/Make/Database/MySQL/templates/database.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/MySQL/templates/database.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 // MySQL Configuration
 define('DB_TYPE', 'mysql');
 

--- a/CorianderCore/core/Console/Commands/Make/Database/SQLite/MakeSQLite.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/SQLite/MakeSQLite.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands\Make\Database\SQLite;
 
@@ -12,17 +13,17 @@ class MakeSQLite
     /**
      * @var string Path to the SQLite templates.
      */
-    protected $templatesPath;
+    protected string $templatesPath;
 
     /**
      * @var string Path to the configuration folder where the SQLite configuration will be saved.
      */
-    protected $configPath;
+    protected string $configPath;
 
     /**
      * @var string Path to the database folder where SQLite database files are stored.
      */
-    protected $databaseFolder;
+    protected string $databaseFolder;
 
     /**
      * Constructor to initialize paths for templates, configuration files, and database folder.
@@ -46,7 +47,7 @@ class MakeSQLite
      *
      * @param string|null $dbName Optional database name. If null, prompts the user for input.
      */
-    public function execute(string $dbName = null)
+    public function execute(?string $dbName = null): void
     {
         // Ask the user for the SQLite database name if not provided
         if (empty($dbName)) {
@@ -69,7 +70,7 @@ class MakeSQLite
      *
      * @param string $dbName The name of the SQLite database.
      */
-    protected function generateConfig($dbName)
+    protected function generateConfig(string $dbName): void
     {
         // Load the SQLite configuration template
         $templatePath = $this->templatesPath . '/database.php';
@@ -87,7 +88,7 @@ class MakeSQLite
      *
      * @param string $dbName The name of the SQLite database.
      */
-    protected function createDatabaseFiles($dbName)
+    protected function createDatabaseFiles(string $dbName): void
     {
         // Ensure the database folder exists
         if (!is_dir($this->databaseFolder)) {
@@ -124,7 +125,7 @@ class MakeSQLite
      *
      * @param string $dbName The name of the SQLite database.
      */
-    protected function createGitignore($dbName)
+    protected function createGitignore(string $dbName): void
     {
         $gitignoreTemplate = file_get_contents($this->templatesPath . '/.gitignore');
         $gitignoreContent = str_replace('{{DB_NAME}}', $dbName, $gitignoreTemplate);
@@ -139,7 +140,7 @@ class MakeSQLite
      *
      * @param string $content The content of the configuration file.
      */
-    protected function saveConfig(string $content)
+    protected function saveConfig(string $content): void
     {
         // Ensure the configuration folder exists
         if (!is_dir($this->configPath)) {

--- a/CorianderCore/core/Console/Commands/Make/Database/SQLite/templates/database.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/SQLite/templates/database.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 // SQLite Configuration
 define('DB_TYPE', 'sqlite');
 

--- a/CorianderCore/core/Console/Commands/Make/Sitemap/MakeSitemap.php
+++ b/CorianderCore/core/Console/Commands/Make/Sitemap/MakeSitemap.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands\Make\Sitemap;
 

--- a/CorianderCore/core/Console/Commands/Make/Sitemap/templates/sitemap.php
+++ b/CorianderCore/core/Console/Commands/Make/Sitemap/templates/sitemap.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 // Set the path to the sitemap.xml file
 $sitemapPath = PROJECT_ROOT . '/public/sitemap.xml';
 

--- a/CorianderCore/core/Console/Commands/Make/View/MakeView.php
+++ b/CorianderCore/core/Console/Commands/Make/View/MakeView.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands\Make\View;
 
@@ -14,14 +15,14 @@ use CorianderCore\Core\Utils\DirectoryHandler;
 class MakeView
 {
     /**
-     * @var string $templatesPath The path to the directory containing view templates.
+     * @var string The path to the directory containing view templates.
      */
-    protected $templatesPath;
+    protected string $templatesPath;
 
     /**
-     * @var string $viewPath The path where the view will be created.
+     * @var string The path where the view will be created.
      */
-    protected $viewPath;
+    protected string $viewPath;
 
     /**
      * Constructor for the MakeView class.
@@ -121,7 +122,7 @@ class MakeView
      * @param string $destinationFile The full path to the destination file (e.g., the new view's index.php).
      * @param string $viewName The name of the view (used to replace placeholders in the template).
      */
-    protected function createFileFromTemplate(string $templateFile, string $destinationFile, string $viewName)
+    protected function createFileFromTemplate(string $templateFile, string $destinationFile, string $viewName): void
     {
         try {
             // Define the full path to the template file.

--- a/CorianderCore/core/Console/Commands/Make/View/templates/metadata.php
+++ b/CorianderCore/core/Console/Commands/Make/View/templates/metadata.php
@@ -1,4 +1,6 @@
 <?php
+declare(strict_types=1);
+
 // Set the language attribute for the <html> tag on the {{viewName}} page.
 $lang = isset($lang) ? $lang : 'en';
 

--- a/CorianderCore/core/Console/Commands/NodeJS.php
+++ b/CorianderCore/core/Console/Commands/NodeJS.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+
+/*
+ * NodeJS command bridges to npm allowing execution of Node scripts from the
+ * CorianderPHP console.
+ */
 
 namespace CorianderCore\Core\Console\Commands;
 
@@ -14,8 +20,9 @@ class NodeJS
      * It captures and outputs the real-time stdout and stderr from the npm process.
      *
      * @param array $args The arguments passed to the 'nodejs' command (e.g., 'install', 'run build').
+     * @return void
      */
-    public function execute(array $args)
+    public function execute(array $args): void
     {
         // Check if any arguments were passed; if not, request a command.
         if (empty($args)) {

--- a/CorianderCore/core/Console/ConsoleOutput.php
+++ b/CorianderCore/core/Console/ConsoleOutput.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+
+/*
+ * ConsoleOutput provides formatted CLI printing using Minecraft-like
+ * color codes to enhance readability of command-line interactions.
+ */
 
 namespace CorianderCore\Core\Console;
 
@@ -37,8 +43,9 @@ class ConsoleOutput
      *  - &r: Reset formatting
      * 
      * @param string $message The message with color/style codes.
+     * @return void
      */
-    public static function print($message)
+    public static function print(string $message): void
     {
         $message = '&7' . $message;
 
@@ -55,8 +62,10 @@ class ConsoleOutput
 
     /**
      * Prints a horizontal rule (line of dashes).
+     *
+     * @return void
      */
-    public static function hr()
+    public static function hr(): void
     {
         self::print("&8-----------------------------------------");
     }

--- a/CorianderCore/core/Console/Services/PdoDriverService.php
+++ b/CorianderCore/core/Console/Services/PdoDriverService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Services;
 

--- a/CorianderCore/core/Database/DatabaseHandler.php
+++ b/CorianderCore/core/Database/DatabaseHandler.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+
+/*
+ * DatabaseHandler manages a single PDO connection shared across the
+ * application, supporting MySQL and SQLite with optional auto-closing.
+ */
 
 namespace CorianderCore\Core\Database;
 
@@ -17,7 +23,7 @@ class DatabaseHandler
     /**
      * @var DatabaseHandler|null Singleton instance of the DatabaseHandler class.
      */
-    private static $instance = null;
+    private static ?DatabaseHandler $instance = null;
 
     /**
      * @var LoggerInterface Logger used for reporting connection issues.
@@ -27,12 +33,12 @@ class DatabaseHandler
     /**
      * @var PDO|null The PDO instance used for database connection, or null if unsupported.
      */
-    private $pdo = null;
+    private ?PDO $pdo = null;
 
     /**
      * @var bool Auto-close flag to determine if the connection should close automatically.
      */
-    private static $autoCloseConnection = true;
+    private static bool $autoCloseConnection = true;
 
     /**
      * Private constructor to prevent direct instantiation.
@@ -78,7 +84,7 @@ class DatabaseHandler
      *
      * @return DatabaseHandler The Singleton instance of the DatabaseHandler.
      */
-    public static function getInstance(?LoggerInterface $logger = null)
+    public static function getInstance(?LoggerInterface $logger = null): DatabaseHandler
     {
         if (self::$instance === null) {
             $logger = $logger ?? new Logger();
@@ -92,17 +98,18 @@ class DatabaseHandler
      * 
      * @return PDO|null The PDO instance for interacting with the database, or null if no connection is available.
      */
-    public function getPDO()
+    public function getPDO(): ?PDO
     {
         return $this->pdo;
     }
 
     /**
      * Set whether the connection should automatically close after each query.
-     * 
+     *
      * @param bool $autoClose Whether to automatically close the connection after each query.
+     * @return void
      */
-    public static function setAutoCloseConnection($autoClose)
+    public static function setAutoCloseConnection(bool $autoClose): void
     {
         self::$autoCloseConnection = $autoClose;
     }
@@ -110,10 +117,12 @@ class DatabaseHandler
     /**
      * Closes the database connection and resets the Singleton instance.
      * If auto-close is disabled, it simply returns without closing the connection.
+     *
+     * @return void
      */
-    public function close()
+    public function close(): void
     {
-        if(!self::$autoCloseConnection) {
+        if (!self::$autoCloseConnection) {
             return;
         }
         $this->pdo = null;

--- a/CorianderCore/core/Database/SQLManager.php
+++ b/CorianderCore/core/Database/SQLManager.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+
+/*
+ * SQLManager offers static CRUD helpers utilising the shared DatabaseHandler
+ * connection to minimise boilerplate across the application.
+ */
 
 namespace CorianderCore\Core\Database;
 
@@ -25,10 +31,10 @@ class SQLManager
      *
      * @param string $columns The columns to select in the SQL query.
      * @param string $from The name of the table from which to retrieve data.
-     * @param array $params Named parameters to bind to the SQL query (optional).
-     * @return array The retrieved data from the table as an associative array.
+     * @param array  $params Named parameters to bind to the SQL query (optional).
+     * @return array|false The retrieved data from the table as an associative array or false on failure.
      */
-    public static function findAll($columns, $from, $params = array())
+    public static function findAll(string $columns, string $from, array $params = []): array|false
     {
         try {
             $db = DatabaseHandler::getInstance(self::getLogger());
@@ -50,10 +56,10 @@ class SQLManager
      * @param string $columns The columns to select in the SQL query.
      * @param string $from The name of the table from which to retrieve data.
      * @param string $where The condition to use for selecting the row.
-     * @param array $params Named parameters to bind to the SQL query (optional).
-     * @return array The retrieved row data as an associative array.
+     * @param array  $params Named parameters to bind to the SQL query (optional).
+     * @return array|false The retrieved row data as an associative array or false on failure.
      */
-    public static function findBy($columns, $from, $where, $params = array())
+    public static function findBy(string $columns, string $from, string $where, array $params = []): array|false
     {
         try {
             $db = DatabaseHandler::getInstance(self::getLogger());
@@ -72,13 +78,13 @@ class SQLManager
     /**
      * Updates data in a table in the database based on a given condition.
      *
-     * @param string $table The name of the table to update.
-     * @param string $set The columns and values to update in the table.
-     * @param string $where The condition to use for selecting the rows to update.
-     * @param array $params Named parameters to bind to the SQL query (optional).
+     * @param string $table  The name of the table to update.
+     * @param string $set    The columns and values to update in the table.
+     * @param string $where  The condition to use for selecting the rows to update.
+     * @param array  $params Named parameters to bind to the SQL query (optional).
      * @return bool True if the update was successful, false otherwise.
      */
-    public static function update($table, $set, $where, $params = array())
+    public static function update(string $table, string $set, string $where, array $params = []): bool
     {
         try {
             $db = DatabaseHandler::getInstance(self::getLogger());
@@ -96,14 +102,14 @@ class SQLManager
     /**
      * Inserts a new row into a table in the database.
      * 
-     * @param string $table The name of the table into which to insert the row.
-     * @param string $into The columns into which to insert values.
+     * @param string $table  The name of the table into which to insert the row.
+     * @param string $into   The columns into which to insert values.
      * @param string $values The values to insert.
-     * @param array $params Parameters to bind to the prepared statement (optional).
-     * 
+     * @param array  $params Parameters to bind to the prepared statement (optional).
+     *
      * @return bool True if the insertion was successful, false otherwise.
      */
-    public static function insertInto($table, $into, $values, $params = array())
+    public static function insertInto(string $table, string $into, string $values, array $params = []): bool
     {
         try {
             $db = DatabaseHandler::getInstance(self::getLogger());
@@ -121,13 +127,13 @@ class SQLManager
     /**
      * Inserts a new row into a table and returns the last inserted ID.
      * 
-     * @param string $table The name of the table to insert into.
-     * @param string $into The columns to insert into.
+     * @param string $table  The name of the table to insert into.
+     * @param string $into   The columns to insert into.
      * @param string $values The values to insert.
-     * @param array $params The parameters to bind to the prepared statement.
-     * @return mixed The last inserted ID on success, false on failure.
+     * @param array  $params The parameters to bind to the prepared statement.
+     * @return string|false The last inserted ID on success, false on failure.
      */
-    public static function insertIntoAndGetId($table, $into, $values, $params = array())
+    public static function insertIntoAndGetId(string $table, string $into, string $values, array $params = []): string|false
     {
         try {
             $db = DatabaseHandler::getInstance(self::getLogger());
@@ -146,12 +152,12 @@ class SQLManager
     /**
      * Deletes rows from a table in the database based on a given condition.
      *
-     * @param string $table The name of the table from which to delete rows.
-     * @param string $where The condition to use for selecting the rows to delete.
-     * @param array $params Named parameters to bind to the SQL query (optional).
+     * @param string $table  The name of the table from which to delete rows.
+     * @param string $where  The condition to use for selecting the rows to delete.
+     * @param array  $params Named parameters to bind to the SQL query (optional).
      * @return bool True if the deletion was successful, false otherwise.
      */
-    public static function deleteFrom($table, $where = '', $params = array())
+    public static function deleteFrom(string $table, string $where = '', array $params = []): bool
     {
         try {
             $db = DatabaseHandler::getInstance(self::getLogger());
@@ -174,10 +180,10 @@ class SQLManager
      * Executes a given SQL query and retrieves a row of data from the database table.
      *
      * @param string $sqlScript The SQL query to execute.
-     * @param array $params Named parameters to bind to the SQL query (optional).
-     * @return array The retrieved row data as an associative array.
+     * @param array  $params    Named parameters to bind to the SQL query (optional).
+     * @return array|false The retrieved row data as an associative array or false on failure.
      */
-    public static function sqlScript($sqlScript, $params = array())
+    public static function sqlScript(string $sqlScript, array $params = []): array|false
     {
         $db = DatabaseHandler::getInstance(self::getLogger());
         $pdo = $db->getPDO();

--- a/CorianderCore/core/Image/ImageHandler.php
+++ b/CorianderCore/core/Image/ImageHandler.php
@@ -1,4 +1,10 @@
 <?php
+declare(strict_types=1);
+
+/*
+ * ImageHandler converts images to WebP and builds responsive <picture> tags
+ * for efficient image delivery.
+ */
 
 namespace CorianderCore\Core\Image;
 
@@ -16,10 +22,15 @@ class ImageHandler
 {
     use StaticLoggerTrait;
 
-    // Path to the image directory
-    private static $imageDir = PROJECT_ROOT;
-    // Subdirectory for storing WebP images
-    private static $webpDir = 'webp/';
+    /**
+     * Path to the base image directory.
+     */
+    private static string $imageDir = PROJECT_ROOT;
+
+    /**
+     * Subdirectory for storing WebP images.
+     */
+    private static string $webpDir = 'webp/';
 
     /**
      * Renders a picture tag with WebP and original format support.
@@ -70,7 +81,7 @@ class ImageHandler
      * @param int $quality The quality for the WebP conversion.
      * @return string|false The path to the WebP image if successful, or false on failure.
      */
-    public static function convertToWebP(string $imagePath, int $quality = 80)
+    public static function convertToWebP(string $imagePath, int $quality = 80): string|false
     {
         $fullImagePath = self::$imageDir . $imagePath;
         

--- a/CorianderCore/core/Logging/Logger.php
+++ b/CorianderCore/core/Logging/Logger.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Logging;
 
@@ -67,7 +68,7 @@ class Logger extends AbstractLogger
      *
      * @return void
      */
-    public function log($level, $message, array $context = []): void
+    public function log(string $level, string|Stringable $message, array $context = []): void
     {
         if (!isset($this->levels[$level])) {
             return;

--- a/CorianderCore/core/Logging/StaticLoggerTrait.php
+++ b/CorianderCore/core/Logging/StaticLoggerTrait.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Logging;
 

--- a/CorianderCore/core/Router/Handlers/ApiControllerHandler.php
+++ b/CorianderCore/core/Router/Handlers/ApiControllerHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Router\Handlers;
 

--- a/CorianderCore/core/Router/Handlers/NotFoundHandler.php
+++ b/CorianderCore/core/Router/Handlers/NotFoundHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Router\Handlers;
 

--- a/CorianderCore/core/Router/Handlers/WebControllerHandler.php
+++ b/CorianderCore/core/Router/Handlers/WebControllerHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Router\Handlers;
 

--- a/CorianderCore/core/Router/Middleware/MiddlewareQueue.php
+++ b/CorianderCore/core/Router/Middleware/MiddlewareQueue.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Router\Middleware;
 

--- a/CorianderCore/core/Router/NameFormatter.php
+++ b/CorianderCore/core/Router/NameFormatter.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Router;
 

--- a/CorianderCore/core/Router/RouteDispatcher.php
+++ b/CorianderCore/core/Router/RouteDispatcher.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Router;
 

--- a/CorianderCore/core/Router/RouteRegistry.php
+++ b/CorianderCore/core/Router/RouteRegistry.php
@@ -1,6 +1,14 @@
 <?php
+declare(strict_types=1);
+
+/*
+ * RouteRegistry stores application routes and the fallback handler for
+ * unmatched requests, acting as a lightweight router configuration store.
+ */
 
 namespace CorianderCore\Core\Router;
+
+use Closure;
 
 /**
  * Manages custom routes and 404 callback.
@@ -13,9 +21,9 @@ class RouteRegistry
     private array $routes = [];
 
     /**
-     * @var callable|null
+     * @var Closure|null
      */
-    private $notFoundCallback = null;
+    private ?Closure $notFoundCallback = null;
 
     /**
      * Register a new route and its handler.
@@ -48,7 +56,7 @@ class RouteRegistry
      */
     public function setNotFound(callable $callback): void
     {
-        $this->notFoundCallback = $callback;
+        $this->notFoundCallback = $callback instanceof Closure ? $callback : Closure::fromCallable($callback);
     }
 
     /**

--- a/CorianderCore/core/Router/Router.php
+++ b/CorianderCore/core/Router/Router.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Router;
 

--- a/CorianderCore/core/Router/Services/ControllerCacheService.php
+++ b/CorianderCore/core/Router/Services/ControllerCacheService.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Router\Services;
 

--- a/CorianderCore/core/Router/ViewRenderer.php
+++ b/CorianderCore/core/Router/ViewRenderer.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Router;
 

--- a/CorianderCore/core/Security/Csrf.php
+++ b/CorianderCore/core/Security/Csrf.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Security;
 

--- a/CorianderCore/core/Security/CsrfMiddleware.php
+++ b/CorianderCore/core/Security/CsrfMiddleware.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Security;
 

--- a/CorianderCore/core/Sitemap/SitemapHandler.php
+++ b/CorianderCore/core/Sitemap/SitemapHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Sitemap;
 

--- a/CorianderCore/core/Utils/DirectoryHandler.php
+++ b/CorianderCore/core/Utils/DirectoryHandler.php
@@ -1,4 +1,5 @@
 <?php
+declare(strict_types=1);
 
 namespace CorianderCore\Core\Utils;
 


### PR DESCRIPTION
## Summary
- add `declare(strict_types=1)` to all core classes and templates
- type hint properties, parameters and return types across the framework
- introduce baseline docs and workflow notes for key services

## Testing
- `composer test`