### PR TITLE
✨ Add route parameters, groups, and middleware

### DIFF
--- a/CorianderCore/core/Router/RouteRegistry.php
+++ b/CorianderCore/core/Router/RouteRegistry.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace CorianderCore\Core\Router;
 
 use Closure;
+use Psr\Http\Server\MiddlewareInterface;
 
 /**
  * Manages custom routes and 404 callback.
@@ -16,7 +17,7 @@ use Closure;
 class RouteRegistry
 {
     /**
-     * @var array<int, array{0:string,1:string,2:callable}>
+     * @var array<int, array{0:string,1:string,2:array<int,string>,3:callable,4:MiddlewareInterface[]}>
      */
     private array $routes = [];
 
@@ -28,20 +29,22 @@ class RouteRegistry
     /**
      * Register a new route and its handler.
      *
-     * @param string   $method  HTTP method for the route.
-     * @param string   $pattern Regex pattern for the route.
-     * @param callable $callback Callback executed for the route.
+     * @param string                $method     HTTP method for the route.
+     * @param string                $pattern    Regex pattern for the route.
+     * @param array<int,string>     $parameters Ordered parameter names.
+     * @param callable              $callback   Callback executed for the route.
+     * @param MiddlewareInterface[] $middleware Route-specific middleware.
      * @return void
      */
-    public function add(string $method, string $pattern, callable $callback): void
+    public function add(string $method, string $pattern, array $parameters, callable $callback, array $middleware): void
     {
-        $this->routes[] = [$method, $pattern, $callback];
+        $this->routes[] = [$method, $pattern, $parameters, $callback, $middleware];
     }
 
     /**
      * Retrieve all registered routes.
      *
-     * @return array<int, array{0:string,1:string,2:callable}>
+     * @return array<int, array{0:string,1:string,2:array<int,string>,3:callable,4:MiddlewareInterface[]}>
      */
     public function getRoutes(): array
     {

--- a/CorianderCore/tests/RouterTest.php
+++ b/CorianderCore/tests/RouterTest.php
@@ -129,7 +129,7 @@ class RouterTest extends TestCase
     #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
     public function testCustomRouteExecution()
     {
-        $this->router->add('GET', '/about', function () {
+        $this->router->add('GET', '/about', function (ServerRequest $request) {
             echo 'About Page Content';
         });
         $request = new ServerRequest('GET', '/about');
@@ -306,8 +306,8 @@ class RouterTest extends TestCase
     public function testRouteParameterExtraction()
     {
         $captured = null;
-        $this->router->add('GET', '/user/{id}', function ($id) use (&$captured) {
-            $captured = $id;
+        $this->router->add('GET', '/user/{id}', function (ServerRequest $request) use (&$captured) {
+            $captured = $request->getAttribute('id');
         });
 
         $request = new ServerRequest('GET', '/user/123');
@@ -325,7 +325,7 @@ class RouterTest extends TestCase
         $request = new ServerRequest('POST', '/user/123');
 
         $executed = false;
-        $this->router->add('GET', '/user/{id}', function () use (&$executed) {
+        $this->router->add('GET', '/user/{id}', function (ServerRequest $request) use (&$executed) {
             $executed = true;
         });
 

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -20,6 +20,37 @@ $router->add('GET', '/hello/{name}', function (ServerRequest $request) {
 $router->setNotFound(fn() => new \Nyholm\Psr7\Response(404, [], 'Not Found'));
 ```
 
+### Route Groups
+
+Group routes to share a common URI prefix or middleware:
+
+```php
+use Psr\Http\Server\MiddlewareInterface;
+
+$auth = new class implements MiddlewareInterface {
+    public function process($request, $handler) {
+        // authentication logic
+        return $handler->handle($request);
+    }
+};
+
+$router->group('/admin', [$auth], function (Router $r) {
+    $r->add('GET', '/dashboard', fn (ServerRequest $req) =>
+        new \Nyholm\Psr7\Response(200, [], 'Dashboard'));
+});
+```
+
+Routes inside the group inherit the `/admin` prefix and the `$auth` middleware.
+
+### Per-route Middleware
+
+Middleware can also be attached directly when registering a route:
+
+```php
+$router->add('GET', '/profile', fn (ServerRequest $r) =>
+    new \Nyholm\Psr7\Response(200, [], 'Profile'), [$auth]);
+```
+
 ## Error Handling
 
 - Register a `setNotFound` callback to handle unmatched routes gracefully.

--- a/public/routes.php
+++ b/public/routes.php
@@ -4,12 +4,12 @@
 // has access to the `$router` and `$notFound` variables.
 
 // Example dynamic route: /user/42 -> "User ID: 42"
-// $router->add('GET', 'user/{id}', function (string $id) {
-//     echo "User ID: {$id}";
+// $router->add('GET', 'user/{id}', function (\Nyholm\Psr7\ServerRequest $request) {
+//     echo 'User ID: ' . $request->getAttribute('id');
 // });
 
 // Route for handling sitemap.xml requests
-$router->add('GET', 'sitemap.xml', function () use ($notFound) {
+$router->add('GET', 'sitemap.xml', function (\Nyholm\Psr7\ServerRequest $request) use ($notFound) {
     $sitemapPath = PROJECT_ROOT . '/public/sitemap.php';
     if (!file_exists($sitemapPath)) {
         $notFound();


### PR DESCRIPTION
## Summary
- support named URI parameters with request attributes
- add route groups with shared prefixes and middleware
- allow per-route middleware storage and execution
- document new routing features

## Testing
- `vendor/bin/phpunit --filter RouterTest`
- `vendor/bin/phpunit --filter RouterIntegrationTest`
- ⚠️ `vendor/bin/phpunit` (hangs after initial progress)