### PR TITLE
Codex/fix framework audit issues

### DIFF
--- a/CorianderCore/Tests/ApiRequestLimitsMiddlewareTest.php
+++ b/CorianderCore/Tests/ApiRequestLimitsMiddlewareTest.php
@@ -108,5 +108,38 @@ class ApiRequestLimitsMiddlewareTest extends TestCase
         $this->assertSame(200, $response->getStatusCode());
         $this->assertSame('stream-data', $capturedBody);
     }
+    public function testSeekableBodyErrorsDoNotBreakRequestFlow(): void
+    {
+        $middleware = new ApiRequestLimitsMiddleware(10, 5);
+        $stream = new class implements StreamInterface {
+            public function __toString(): string { return ''; }
+            public function close(): void {}
+            public function detach() { return null; }
+            public function getSize(): ?int { return null; }
+            public function tell(): int { throw new \RuntimeException('tell failed'); }
+            public function eof(): bool { return true; }
+            public function isSeekable(): bool { return true; }
+            public function seek($offset, $whence = SEEK_SET): void { throw new \RuntimeException('seek failed'); }
+            public function rewind(): void { throw new \RuntimeException('rewind failed'); }
+            public function isWritable(): bool { return false; }
+            public function write($string): int { throw new \RuntimeException('not writable'); }
+            public function isReadable(): bool { return true; }
+            public function read($length): string { return ''; }
+            public function getContents(): string { return ''; }
+            public function getMetadata($key = null) { return null; }
+        };
+
+        $request = new ServerRequest('POST', '/api/items', [], $stream);
+
+        $response = $middleware->process($request, new class implements RequestHandlerInterface {
+            public function handle(\Psr\Http\Message\ServerRequestInterface $request): \Psr\Http\Message\ResponseInterface
+            {
+                return new Response(200, [], 'ok');
+            }
+        });
+
+        $this->assertSame(200, $response->getStatusCode());
+        $this->assertSame('ok', (string) $response->getBody());
+    }
 }
 

--- a/CorianderCore/Tests/FrameworkFileSyncServiceIntegrationTest.php
+++ b/CorianderCore/Tests/FrameworkFileSyncServiceIntegrationTest.php
@@ -111,6 +111,45 @@ class FrameworkFileSyncServiceIntegrationTest extends TestCase
 
         new FrameworkFileSyncService($this->root, ['CorianderCore'], '../outside');
     }
+
+    public function testApplyPlanRejectsTraversalBackupScope(): void
+    {
+        $destination = $this->root . '/CorianderCore/core/safe.txt';
+        $source = $this->root . '/source/safe.txt';
+
+        mkdir(dirname($destination), 0775, true);
+        mkdir(dirname($source), 0775, true);
+
+        file_put_contents($destination, 'current');
+        file_put_contents($source, 'updated');
+
+        $plan = [
+            'operations' => [
+                [
+                    'type' => 'update',
+                    'relative_path' => 'CorianderCore/core/safe.txt',
+                    'source' => $source,
+                    'destination' => $destination,
+                ],
+            ],
+        ];
+
+        $service = new FrameworkFileSyncService($this->root, ['CorianderCore']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('path traversal');
+        $service->applyPlan($plan, true, true, '../escape');
+    }
+
+    public function testRollbackBackupScopeRejectsTraversalScope(): void
+    {
+        $service = new FrameworkFileSyncService($this->root, ['CorianderCore']);
+
+        $this->expectException(\RuntimeException::class);
+        $this->expectExceptionMessage('path traversal');
+        $service->rollbackBackupScope('../escape');
+    }
+
     private function deleteDirectory(string $directory): void
     {
         if (!is_dir($directory)) {
@@ -138,5 +177,3 @@ class FrameworkFileSyncServiceIntegrationTest extends TestCase
         @rmdir($directory);
     }
 }
-
-

--- a/CorianderCore/Tests/SQLManagerTest.php
+++ b/CorianderCore/Tests/SQLManagerTest.php
@@ -81,4 +81,23 @@ class SQLManagerTest extends TestCase
         $this->assertCount(1, $rows);
         $this->assertSame('bob', $rows[0]['name']);
     }
+
+    public function testBuildColumnListSupportsQualifiedWildcard(): void
+    {
+        $method = new \ReflectionMethod(SQLManager::class, 'buildColumnList');
+        $method->setAccessible(true);
+
+        $columnList = $method->invoke(null, ['users.*', 'users.name']);
+
+        $this->assertSame('`users`.*, `users`.`name`', $columnList);
+    }
+
+    public function testQuoteIdentifierRejectsEmptyIdentifier(): void
+    {
+        $method = new \ReflectionMethod(SQLManager::class, 'quoteIdentifier');
+        $method->setAccessible(true);
+
+        $this->expectException(DatabaseException::class);
+        $method->invoke(null, '');
+    }
 }

--- a/CorianderCore/Tests/ViewRendererTest.php
+++ b/CorianderCore/Tests/ViewRendererTest.php
@@ -91,3 +91,4 @@ class ViewRendererTest extends TestCase
         @rmdir($directory);
     }
 }
+

--- a/CorianderCore/core/Benchmark/BenchmarkHandler.php
+++ b/CorianderCore/core/Benchmark/BenchmarkHandler.php
@@ -189,11 +189,33 @@ class BenchmarkHandler
      */
     public function getCpuCores(): int
     {
-        if (stripos(PHP_OS, 'WIN') === 0) {
-            // Windows command to get the number of CPU cores
-            return (int)shell_exec('wmic cpu get NumberOfCores | findstr /r /r "[0-9]"');
+        $windowsCores = getenv('NUMBER_OF_PROCESSORS');
+        if (is_string($windowsCores) && ctype_digit($windowsCores) && (int) $windowsCores > 0) {
+            return (int) $windowsCores;
         }
-        return (int)shell_exec('nproc');
+
+        $procCpuInfo = '/proc/cpuinfo';
+        if (is_readable($procCpuInfo)) {
+            $content = (string) file_get_contents($procCpuInfo);
+            preg_match_all('/^processor\s*:/m', $content, $matches);
+            if (!empty($matches[0])) {
+                return count($matches[0]);
+            }
+        }
+
+        $cpuPresent = '/sys/devices/system/cpu/present';
+        if (is_readable($cpuPresent)) {
+            $content = trim((string) file_get_contents($cpuPresent));
+            if (preg_match('/^(\d+)-(\d+)$/', $content, $matches) === 1) {
+                $start = (int) $matches[1];
+                $end = (int) $matches[2];
+                if ($end >= $start) {
+                    return ($end - $start) + 1;
+                }
+            }
+        }
+
+        return 1;
     }
 
     /**
@@ -369,4 +391,6 @@ class BenchmarkHandler
         ];
     }
 }
+
+
 

--- a/CorianderCore/core/Benchmark/BenchmarkHandler.php
+++ b/CorianderCore/core/Benchmark/BenchmarkHandler.php
@@ -8,6 +8,8 @@ declare(strict_types=1);
 
 namespace CorianderCore\Core\Benchmark;
 
+use InvalidArgumentException;
+
 /**
  * BenchmarkHandler is responsible for measuring key performance indicators
  * such as initialization speed, memory usage, throughput, latency, CPU usage, and file inclusion tracking.
@@ -120,7 +122,12 @@ class BenchmarkHandler
      */
     public function getThroughput(int $operations): float
     {
-        return $operations / $this->getInitializationTime();
+        $elapsed = $this->getInitializationTime();
+        if ($operations <= 0 || $elapsed <= 0.0) {
+            return 0.0;
+        }
+
+        return $operations / $elapsed;
     }
 
     /**
@@ -131,6 +138,10 @@ class BenchmarkHandler
      */
     public function getLatency(int $operations): float
     {
+        if ($operations <= 0) {
+            return 0.0;
+        }
+
         return $this->getInitializationTime() / $operations;
     }
 
@@ -164,6 +175,10 @@ class BenchmarkHandler
      */
     public function getAverageCpuUsagePerOperation(int $operations): float
     {
+        if ($operations <= 0) {
+            return 0.0;
+        }
+
         return $this->getTotalCpuUsage() / $operations;
     }
 
@@ -299,6 +314,10 @@ class BenchmarkHandler
      */
     public function benchmarkFunction(callable $function, int $duration): array
     {
+        if ($duration <= 0) {
+            throw new InvalidArgumentException('Benchmark duration must be greater than 0 seconds.');
+        }
+
         // Initialize benchmark
         $this->start();
 
@@ -350,3 +369,4 @@ class BenchmarkHandler
         ];
     }
 }
+

--- a/CorianderCore/core/Bootstrap/TimezoneBootstrap.php
+++ b/CorianderCore/core/Bootstrap/TimezoneBootstrap.php
@@ -6,6 +6,11 @@ namespace CorianderCore\Core\Bootstrap;
 class TimezoneBootstrap
 {
     /**
+     * @var array<string, bool>|null
+     */
+    private static ?array $timezoneIndex = null;
+
+    /**
      * Apply app timezone from environment value when valid.
      */
     public static function applyFromEnvironment(?string $timezone): bool
@@ -14,7 +19,11 @@ class TimezoneBootstrap
             return false;
         }
 
-        if (!in_array($timezone, timezone_identifiers_list(), true)) {
+        if (self::$timezoneIndex === null) {
+            self::$timezoneIndex = array_fill_keys(timezone_identifiers_list(), true);
+        }
+
+        if (!isset(self::$timezoneIndex[$timezone])) {
             return false;
         }
 

--- a/CorianderCore/core/Console/Services/Updater/FrameworkFileSyncService.php
+++ b/CorianderCore/core/Console/Services/Updater/FrameworkFileSyncService.php
@@ -321,9 +321,8 @@ final class FrameworkFileSyncService
     {
         $relativePath = $this->toRelativeProjectPath($destinationFile);
         $baseDirectory = $this->normalizeBackupDirectory($backupDirectory ?? $this->defaultBackupDirectory);
-        $scopeSegment = $backupScope !== null && trim($backupScope) !== ''
-            ? '/' . trim(str_replace('\\', '/', $backupScope), '/')
-            : '';
+        $normalizedScope = $this->normalizeBackupScope($backupScope);
+        $scopeSegment = $normalizedScope !== '' ? '/' . $normalizedScope : '';
 
         $backupPath = $this->projectRoot . '/' . $baseDirectory . $scopeSegment . '/' . $relativePath . '.bak';
         $suffix = 0;
@@ -564,7 +563,11 @@ final class FrameworkFileSyncService
     private function resolveBackupScopePath(string $scope, ?string $backupDirectory = null): string
     {
         $baseDirectory = $this->normalizeBackupDirectory($backupDirectory ?? $this->defaultBackupDirectory);
-        $normalizedScope = trim(str_replace('\\', '/', $scope), '/');
+        $normalizedScope = $this->normalizeBackupScope($scope);
+        if ($normalizedScope === '') {
+            throw new RuntimeException('Backup scope cannot be empty.');
+        }
+
         return $this->projectRoot . '/' . $baseDirectory . '/' . $normalizedScope;
     }
     private function deleteTemporaryDirectory(string $directory): void
@@ -608,7 +611,7 @@ final class FrameworkFileSyncService
             throw new RuntimeException('Backup directory contains invalid null-byte characters.');
         }
 
-        $normalized = str_replace('\\', '/', trim($backupDirectory));
+        $normalized = str_replace("\\", "/", trim($backupDirectory));
         if ($normalized === '') {
             return 'backups/coriander';
         }
@@ -631,9 +634,34 @@ final class FrameworkFileSyncService
         return implode('/', $segments);
     }
 
-    /**
-     * @param array<int, array{type:string,destination:string,backup_absolute:string|null}> $appliedOperations
-     */
+    private function normalizeBackupScope(?string $scope): string
+    {
+        if ($scope === null) {
+            return '';
+        }
+
+        if (str_contains($scope, "\0")) {
+            throw new RuntimeException('Backup scope contains invalid null-byte characters.');
+        }
+
+        $normalized = str_replace("\\", "/", trim($scope));
+        if ($normalized === '') {
+            return '';
+        }
+
+        if (str_starts_with($normalized, '/') || preg_match('/^[A-Za-z]:\//', $normalized) === 1) {
+            throw new RuntimeException('Backup scope must be relative to the backup directory.');
+        }
+
+        $segments = array_values(array_filter(explode('/', trim($normalized, '/')), static fn(string $segment): bool => $segment !== ''));
+        foreach ($segments as $segment) {
+            if ($segment === '.' || $segment === '..') {
+                throw new RuntimeException('Backup scope cannot contain path traversal segments.');
+            }
+        }
+
+        return implode('/', $segments);
+    }
     private function rollbackAppliedOperations(array $appliedOperations): ?string
     {
         $restoreFailures = [];
@@ -673,6 +701,7 @@ final class FrameworkFileSyncService
         return $normalizedAbsolute;
     }
 }
+
 
 
 

--- a/CorianderCore/core/Database/SQLManager.php
+++ b/CorianderCore/core/Database/SQLManager.php
@@ -393,9 +393,7 @@ class SQLManager
 
             if (str_ends_with($column, '.*')) {
                 $prefix = substr($column, 0, -2);
-                if ($prefix !== '' && preg_match('/^[a-zA-Z0-9_]+$/', $prefix) === 1) {
-                    return self::quoteIdentifier($prefix) . '.*';
-                }
+                return self::quoteIdentifier($prefix) . '.*';
             }
 
             return self::quoteIdentifier($column);
@@ -411,6 +409,21 @@ class SQLManager
      */
     private static function quoteIdentifier(string $identifier): string
     {
-        return '`' . str_replace('`', '``', $identifier) . '`';
+        $trimmed = trim($identifier);
+        if ($trimmed === '') {
+            throw new DatabaseException('Identifier cannot be empty.');
+        }
+
+        $parts = explode('.', $trimmed);
+        $quotedParts = [];
+        foreach ($parts as $part) {
+            if ($part === '') {
+                throw new DatabaseException('Identifier contains an empty segment.');
+            }
+            $quotedParts[] = '`' . str_replace('`', '``', $part) . '`';
+        }
+
+        return implode('.', $quotedParts);
     }
 }
+

--- a/CorianderCore/core/Database/SQLManager.php
+++ b/CorianderCore/core/Database/SQLManager.php
@@ -145,6 +145,7 @@ class SQLManager
      */
     public static function findBy(array $columns, string $table, string $where, array $params = []): array
     {
+        @trigger_error('SQLManager::findBy() is deprecated. Use findWhere() for simple equality conditions.', E_USER_DEPRECATED);
         try {
             $pdo = self::requirePdo();
             $columnList = self::buildColumnList($columns);
@@ -188,6 +189,7 @@ class SQLManager
      */
     public static function update(string $table, array $data, string $where, array $params = []): bool
     {
+        @trigger_error('SQLManager::update() is deprecated. Use updateWhere() for simple equality conditions.', E_USER_DEPRECATED);
         try {
             $pdo = self::requirePdo();
             $table = self::quoteIdentifier($table);
@@ -291,6 +293,7 @@ class SQLManager
      */
     public static function deleteFrom(string $table, string $where = '', array $params = []): bool
     {
+        @trigger_error('SQLManager::deleteFrom() is deprecated. Use deleteWhere() for simple equality conditions.', E_USER_DEPRECATED);
         try {
             $pdo = self::requirePdo();
             $table = self::quoteIdentifier($table);

--- a/CorianderCore/core/Image/ImageHandler.php
+++ b/CorianderCore/core/Image/ImageHandler.php
@@ -57,17 +57,26 @@ class ImageHandler
             [$width, $height] = $imageSize;
         }
 
+        $safePictureClass = self::escapeHtmlAttribute($pictureClass);
+        $safeImgClass = self::escapeHtmlAttribute($imgClass);
+        $safeAltText = self::escapeHtmlAttribute($altText);
+
         // Prepare the HTML for the <picture> element
-        $pictureHTML = "<picture class=\"$pictureClass\">";
+        $pictureHTML = "<picture class=\"{$safePictureClass}\">";
         
         if ($webpPath) {
-            $webpRelativePath = self::getRelativePath($webpPath);
-            $pictureHTML .= "<source srcset=\"$webpRelativePath\" type=\"image/webp\" />";
+            $webpRelativePath = self::escapeHtmlAttribute(self::getRelativePath($webpPath));
+            $pictureHTML .= "<source srcset=\"{$webpRelativePath}\" type=\"image/webp\" />";
         }
         
-        $originalRelativePath = self::getRelativePath($fullImagePath);
-        $pictureHTML .= "<source srcset=\"$originalRelativePath\" type=\"image/" . pathinfo($imagePath, PATHINFO_EXTENSION) . "\" />";
-        $pictureHTML .= "<img alt='$altText' width=\"$width\" height=\"$height\" class=\"$imgClass\" src=\"$originalRelativePath\" />";
+        $originalRelativePath = self::escapeHtmlAttribute(self::getRelativePath($fullImagePath));
+        $originalExtension = strtolower((string) pathinfo($imagePath, PATHINFO_EXTENSION));
+        $safeOriginalType = preg_replace('/[^a-z0-9.+-]/', '', $originalExtension);
+        $safeWidth = $width !== '' ? (string) (int) $width : '';
+        $safeHeight = $height !== '' ? (string) (int) $height : '';
+
+        $pictureHTML .= "<source srcset=\"{$originalRelativePath}\" type=\"image/{$safeOriginalType}\" />";
+        $pictureHTML .= "<img alt=\"{$safeAltText}\" width=\"{$safeWidth}\" height=\"{$safeHeight}\" class=\"{$safeImgClass}\" src=\"{$originalRelativePath}\" />";
         
         $pictureHTML .= "</picture>";
         
@@ -163,6 +172,11 @@ class ImageHandler
     private static function getRelativePath(string $fullPath): string
     {
         return str_replace(self::$imageDir, '', $fullPath);
+    }
+
+    private static function escapeHtmlAttribute(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
 }
 

--- a/CorianderCore/core/Image/ImageHandler.php
+++ b/CorianderCore/core/Image/ImageHandler.php
@@ -44,11 +44,21 @@ class ImageHandler
      */
     public static function render(string $imagePath, string $altText = '', string $pictureClass = '', string $imgClass = '', int $quality = 80): string
     {
+        $normalizedPath = self::normalizeImagePath($imagePath);
+        if ($normalizedPath === null) {
+            self::getLogger()->warning('Rejected unsafe image path: ' . $imagePath);
+            return '';
+        }
+
         // Convert the image to WebP format if it doesn't already exist
-        $webpPath = self::convertToWebP($imagePath, $quality);
+        $webpPath = self::convertToWebP($normalizedPath, $quality);
 
         // Generate the paths for the original image and WebP image
-        $fullImagePath = self::$imageDir . $imagePath;
+        $fullImagePath = self::resolveFullImagePath($normalizedPath);
+        if ($fullImagePath === null) {
+            self::getLogger()->warning('Unable to resolve image path: ' . $normalizedPath);
+            return '';
+        }
 
         // Check if the original image exists to get dimensions; otherwise, set default dimensions
         $imageSize = @getimagesize($fullImagePath);
@@ -63,23 +73,23 @@ class ImageHandler
 
         // Prepare the HTML for the <picture> element
         $pictureHTML = "<picture class=\"{$safePictureClass}\">";
-        
+
         if ($webpPath) {
-            $webpRelativePath = self::escapeHtmlAttribute(self::getRelativePath($webpPath));
+            $webpRelativePath = self::escapeHtmlAttribute(self::getWebPRelativePath($normalizedPath, $quality));
             $pictureHTML .= "<source srcset=\"{$webpRelativePath}\" type=\"image/webp\" />";
         }
-        
-        $originalRelativePath = self::escapeHtmlAttribute(self::getRelativePath($fullImagePath));
-        $originalExtension = strtolower((string) pathinfo($imagePath, PATHINFO_EXTENSION));
+
+        $originalRelativePath = self::escapeHtmlAttribute($normalizedPath);
+        $originalExtension = strtolower((string) pathinfo($normalizedPath, PATHINFO_EXTENSION));
         $safeOriginalType = preg_replace('/[^a-z0-9.+-]/', '', $originalExtension);
         $safeWidth = $width !== '' ? (string) (int) $width : '';
         $safeHeight = $height !== '' ? (string) (int) $height : '';
 
         $pictureHTML .= "<source srcset=\"{$originalRelativePath}\" type=\"image/{$safeOriginalType}\" />";
         $pictureHTML .= "<img alt=\"{$safeAltText}\" width=\"{$safeWidth}\" height=\"{$safeHeight}\" class=\"{$safeImgClass}\" src=\"{$originalRelativePath}\" />";
-        
+
         $pictureHTML .= "</picture>";
-        
+
         return $pictureHTML;
     }
 
@@ -92,14 +102,24 @@ class ImageHandler
      */
     public static function convertToWebP(string $imagePath, int $quality = 80): string|false
     {
-        $fullImagePath = self::$imageDir . $imagePath;
-        
+        $normalizedPath = self::normalizeImagePath($imagePath);
+        if ($normalizedPath === null) {
+            self::getLogger()->warning('Rejected unsafe image path: ' . $imagePath);
+            return false;
+        }
+
+        $fullImagePath = self::resolveFullImagePath($normalizedPath);
+        if ($fullImagePath === null) {
+            self::getLogger()->warning('Unable to resolve image path: ' . $normalizedPath);
+            return false;
+        }
+
         if (!file_exists($fullImagePath)) {
             self::getLogger()->warning('Image not found: ' . $fullImagePath);
             return false;
         }
 
-        $webpPath = self::getWebPPath($imagePath, $quality);
+        $webpPath = self::getWebPPath($normalizedPath, $quality);
 
         // If WebP file already exists, no need to convert
         if (file_exists($webpPath)) {
@@ -160,18 +180,67 @@ class ImageHandler
     private static function getWebPPath(string $imagePath, int $quality): string
     {
         $imagePathInfo = pathinfo($imagePath);
-        return self::$imageDir . $imagePathInfo['dirname'] . '/' . self::$webpDir . $imagePathInfo['filename'] . "_{$quality}.webp";
+        $directory = trim((string) ($imagePathInfo['dirname'] ?? ''), '/');
+        $basePath = self::normalizeBaseDirectory() . ($directory !== '' ? $directory . '/' : '');
+
+        return $basePath . self::$webpDir . $imagePathInfo['filename'] . "_{$quality}.webp";
     }
 
-    /**
-     * Returns the relative path of the image from the base directory.
-     *
-     * @param string $fullPath The full path to the image.
-     * @return string The relative path.
-     */
-    private static function getRelativePath(string $fullPath): string
+    private static function getWebPRelativePath(string $imagePath, int $quality): string
     {
-        return str_replace(self::$imageDir, '', $fullPath);
+        $imagePathInfo = pathinfo($imagePath);
+        $directory = trim((string) ($imagePathInfo['dirname'] ?? ''), '/');
+        $basePath = '/' . ($directory !== '' ? $directory . '/' : '');
+
+        return $basePath . self::$webpDir . $imagePathInfo['filename'] . "_{$quality}.webp";
+    }
+
+    private static function resolveFullImagePath(string $imagePath): ?string
+    {
+        $fullPath = self::normalizeBaseDirectory() . ltrim($imagePath, '/');
+        $resolved = realpath($fullPath);
+        if ($resolved === false) {
+            return null;
+        }
+
+        $baseDirectory = rtrim(realpath(self::normalizeBaseDirectory()) ?: self::normalizeBaseDirectory(), DIRECTORY_SEPARATOR) . DIRECTORY_SEPARATOR;
+        if (!str_starts_with($resolved, $baseDirectory)) {
+            return null;
+        }
+
+        return $resolved;
+    }
+
+    private static function normalizeImagePath(string $imagePath): ?string
+    {
+        if ($imagePath === '' || str_contains($imagePath, "\0")) {
+            return null;
+        }
+
+        $path = str_replace('\\', '/', trim($imagePath));
+        $segments = explode('/', ltrim($path, '/'));
+        $normalized = [];
+
+        foreach ($segments as $segment) {
+            if ($segment === '' || $segment === '.') {
+                continue;
+            }
+            if ($segment === '..') {
+                return null;
+            }
+            $normalized[] = $segment;
+        }
+
+        if ($normalized === []) {
+            return null;
+        }
+
+        return '/' . implode('/', $normalized);
+    }
+
+    private static function normalizeBaseDirectory(): string
+    {
+        return rtrim(str_replace('\\', '/', self::$imageDir), '/') . '/';
     }
 
     private static function escapeHtmlAttribute(string $value): string
@@ -179,4 +248,3 @@ class ImageHandler
         return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
     }
 }
-

--- a/CorianderCore/core/Router/Handlers/ApiControllerHandler.php
+++ b/CorianderCore/core/Router/Handlers/ApiControllerHandler.php
@@ -6,8 +6,6 @@ namespace CorianderCore\Core\Router\Handlers;
 use CorianderCore\Core\Router\NameFormatter;
 use Nyholm\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
-use ReflectionException;
-use ReflectionMethod;
 
 /**
  * Handles dispatching to API controllers based on RESTful methods and subpaths.
@@ -65,7 +63,7 @@ class ApiControllerHandler
 
         $params = array_slice($segments, 2);
 
-        if (!$this->isPublicInvokableAction($controller, $action)) {
+        if (!ControllerActionInspector::isPublicInvokable($controller, $action)) {
             return null;
         }
 
@@ -115,20 +113,6 @@ class ApiControllerHandler
 
         json_decode($payload, true);
         return json_last_error() === JSON_ERROR_NONE;
-    }
-    private function isPublicInvokableAction(object $controller, string $action): bool
-    {
-        if (!method_exists($controller, $action)) {
-            return false;
-        }
-
-        try {
-            $method = new ReflectionMethod($controller, $action);
-        } catch (ReflectionException) {
-            return false;
-        }
-
-        return $method->isPublic() && !$method->isStatic();
     }
 
     private function controllerExists(string $controllerClass): bool

--- a/CorianderCore/core/Router/Handlers/ApiControllerHandler.php
+++ b/CorianderCore/core/Router/Handlers/ApiControllerHandler.php
@@ -82,9 +82,29 @@ class ApiControllerHandler
             return new Response(204, ['Content-Type' => 'application/json; charset=utf-8']);
         }
 
-        return new Response(200, ['Content-Type' => 'application/json; charset=utf-8'], $content);
+        $trimmedContent = trim($content);
+        if ($this->isJsonPayload($trimmedContent)) {
+            return new Response(200, ['Content-Type' => 'application/json; charset=utf-8'], $trimmedContent);
+        }
+
+        $encoded = json_encode(['data' => $content], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        if (!is_string($encoded)) {
+            $encoded = '{"data":""}';
+        }
+
+        return new Response(200, ['Content-Type' => 'application/json; charset=utf-8'], $encoded);
     }
 
+
+    private function isJsonPayload(string $payload): bool
+    {
+        if ($payload === '') {
+            return false;
+        }
+
+        json_decode($payload, true);
+        return json_last_error() === JSON_ERROR_NONE;
+    }
     private function isPublicInvokableAction(object $controller, string $action): bool
     {
         if (!method_exists($controller, $action)) {
@@ -120,3 +140,4 @@ class ApiControllerHandler
         return PROJECT_ROOT . '/src/ApiControllers/' . $shortName . '.php';
     }
 }
+

--- a/CorianderCore/core/Router/Handlers/ApiControllerHandler.php
+++ b/CorianderCore/core/Router/Handlers/ApiControllerHandler.php
@@ -15,6 +15,16 @@ use ReflectionMethod;
 class ApiControllerHandler
 {
     /**
+     * @var callable(string):object
+     */
+    private $controllerFactory;
+
+    public function __construct(?callable $controllerFactory = null)
+    {
+        $this->controllerFactory = $controllerFactory ?? static fn(string $className): object => new $className();
+    }
+
+    /**
      * Dispatch an API request to the appropriate controller action.
      *
      * Parses the path to determine the controller and action method based on
@@ -44,7 +54,8 @@ class ApiControllerHandler
             return null;
         }
 
-        $controller = new $controllerClass();
+        $factory = $this->controllerFactory;
+        $controller = $factory($controllerClass);
 
         $action = strtolower($method);
         if (isset($segments[1]) && $segments[1] !== '') {
@@ -140,4 +151,3 @@ class ApiControllerHandler
         return PROJECT_ROOT . '/src/ApiControllers/' . $shortName . '.php';
     }
 }
-

--- a/CorianderCore/core/Router/Handlers/ControllerActionInspector.php
+++ b/CorianderCore/core/Router/Handlers/ControllerActionInspector.php
@@ -1,0 +1,25 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Core\Router\Handlers;
+
+use ReflectionException;
+use ReflectionMethod;
+
+final class ControllerActionInspector
+{
+    public static function isPublicInvokable(object $controller, string $action): bool
+    {
+        if (!method_exists($controller, $action)) {
+            return false;
+        }
+
+        try {
+            $method = new ReflectionMethod($controller, $action);
+        } catch (ReflectionException) {
+            return false;
+        }
+
+        return $method->isPublic() && !$method->isStatic();
+    }
+}

--- a/CorianderCore/core/Router/Handlers/WebControllerHandler.php
+++ b/CorianderCore/core/Router/Handlers/WebControllerHandler.php
@@ -27,6 +27,11 @@ class WebControllerHandler
      */
     private ControllerCacheService $cacheService;
 
+
+    /**
+     * @var callable(string):object
+     */
+    private $controllerFactory;
     /**
      * Cache for existence checks to avoid redundant filesystem lookups.
      *
@@ -34,9 +39,10 @@ class WebControllerHandler
      */
     private array $controllerExistenceCache = [];
 
-    public function __construct(?ControllerCacheService $cacheService = null)
+    public function __construct(?ControllerCacheService $cacheService = null, ?callable $controllerFactory = null)
     {
-        $this->cacheService = $cacheService ?? ControllerCacheService::getInstance();
+        $this->cacheService = $cacheService ?? new ControllerCacheService();
+        $this->controllerFactory = $controllerFactory ?? static fn(string $className): object => new $className();
     }
 
     /**
@@ -63,7 +69,8 @@ class WebControllerHandler
             return null;
         }
 
-        $controller = new $controllerClass();
+        $factory = $this->controllerFactory;
+        $controller = $factory($controllerClass);
 
         ob_start();
         [$handled, $result] = $this->dispatchAction($controller, $segments, $method);
@@ -198,3 +205,4 @@ class WebControllerHandler
         return $this->controllerExistenceCache[$controllerClass] = false;
     }
 }
+

--- a/CorianderCore/core/Router/Handlers/WebControllerHandler.php
+++ b/CorianderCore/core/Router/Handlers/WebControllerHandler.php
@@ -7,8 +7,6 @@ use CorianderCore\Core\Router\NameFormatter;
 use CorianderCore\Core\Router\Services\ControllerCacheService;
 use Nyholm\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
-use ReflectionMethod;
-use ReflectionException;
 
 /**
  * Handles dispatching to web controllers by resolving controller class and action from a URL path.
@@ -133,15 +131,15 @@ class WebControllerHandler
 
         $params = array_slice($segments, 2);
 
-        if ($action !== 'index' && $this->isPublicInvokableAction($controller, $action)) {
+        if ($action !== 'index' && ControllerActionInspector::isPublicInvokable($controller, $action)) {
             return [true, call_user_func_array([$controller, $action], $params)];
         }
 
-        if ($method === 'POST' && $this->isPublicInvokableAction($controller, 'store')) {
+        if ($method === 'POST' && ControllerActionInspector::isPublicInvokable($controller, 'store')) {
             return [true, call_user_func_array([$controller, 'store'], $params)];
         }
 
-        if ($this->isPublicInvokableAction($controller, $action)) {
+        if (ControllerActionInspector::isPublicInvokable($controller, $action)) {
             return [true, call_user_func_array([$controller, $action], $params)];
         }
 
@@ -155,21 +153,6 @@ class WebControllerHandler
         }
 
         return preg_match('/^[a-zA-Z][a-zA-Z0-9_]*$/', $action) === 1;
-    }
-
-    private function isPublicInvokableAction(object $controller, string $action): bool
-    {
-        if (!method_exists($controller, $action)) {
-            return false;
-        }
-
-        try {
-            $method = new ReflectionMethod($controller, $action);
-        } catch (ReflectionException) {
-            return false;
-        }
-
-        return $method->isPublic() && !$method->isStatic();
     }
 
     /**
@@ -205,4 +188,3 @@ class WebControllerHandler
         return $this->controllerExistenceCache[$controllerClass] = false;
     }
 }
-

--- a/CorianderCore/core/Router/RouteDispatcher.php
+++ b/CorianderCore/core/Router/RouteDispatcher.php
@@ -42,9 +42,6 @@ class RouteDispatcher
             $path = 'home';
         }
 
-        $requestedView = $this->normalizeRequestedView($path) ?? 'home';
-        defined('REQUESTED_VIEW') || define('REQUESTED_VIEW', $requestedView);
-
         $method = strtoupper($request->getMethod());
         $allowedMethods = [];
 
@@ -117,31 +114,5 @@ class RouteDispatcher
         return $this->notFoundHandler->handle($this->registry);
     }
 
-    /**
-     * Normalize a requested view path into safe relative segments.
-     */
-    private function normalizeRequestedView(string $path): ?string
-    {
-        if (str_contains($path, "\0")) {
-            return null;
-        }
-
-        $normalizedPath = str_replace('\\', '/', trim($path));
-        if ($normalizedPath === '' || str_starts_with($normalizedPath, '/')) {
-            return null;
-        }
-
-        if (preg_match('/^[a-zA-Z]:\//', $normalizedPath) === 1) {
-            return null;
-        }
-
-        $segments = explode('/', trim($normalizedPath, '/'));
-        foreach ($segments as $segment) {
-            if ($segment === '' || $segment === '.' || $segment === '..') {
-                return null;
-            }
-        }
-
-        return implode('/', $segments);
-    }
 }
+

--- a/CorianderCore/core/Router/SafePath.php
+++ b/CorianderCore/core/Router/SafePath.php
@@ -1,0 +1,35 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Core\Router;
+
+/**
+ * Shared guard for user-provided relative path segments used by routing/views.
+ */
+final class SafePath
+{
+    public static function normalizeRelativePath(string $path): ?string
+    {
+        if (str_contains($path, "\0")) {
+            return null;
+        }
+
+        $normalizedPath = str_replace('\\', '/', trim($path));
+        if ($normalizedPath === '' || str_starts_with($normalizedPath, '/')) {
+            return null;
+        }
+
+        if (preg_match('/^[a-zA-Z]:\//', $normalizedPath) === 1) {
+            return null;
+        }
+
+        $segments = explode('/', trim($normalizedPath, '/'));
+        foreach ($segments as $segment) {
+            if ($segment === '' || $segment === '.' || $segment === '..') {
+                return null;
+            }
+        }
+
+        return implode('/', $segments);
+    }
+}

--- a/CorianderCore/core/Router/Services/ControllerCacheService.php
+++ b/CorianderCore/core/Router/Services/ControllerCacheService.php
@@ -87,12 +87,23 @@ class ControllerCacheService
             }
         }
 
-        if (!is_dir(dirname($this->cacheFile))) {
-            mkdir(dirname($this->cacheFile), 0777, true);
+        $cacheDirectory = dirname($this->cacheFile);
+        if (!is_dir($cacheDirectory) && !mkdir($cacheDirectory, 0775, true) && !is_dir($cacheDirectory)) {
+            throw new \RuntimeException('Unable to create controller cache directory.');
         }
 
         $content = "<?php\nreturn " . var_export($controllers, true) . ";\n";
-        file_put_contents($this->cacheFile, $content);
+        $temporaryFile = $this->cacheFile . '.tmp.' . bin2hex(random_bytes(8));
+
+        if (file_put_contents($temporaryFile, $content, LOCK_EX) === false) {
+            throw new \RuntimeException('Unable to write controller cache file.');
+        }
+
+        if (!@rename($temporaryFile, $this->cacheFile)) {
+            @unlink($temporaryFile);
+            throw new \RuntimeException('Unable to replace controller cache file atomically.');
+        }
+
         self::$cacheStore[$this->cacheFile] = $controllers;
     }
 
@@ -107,3 +118,4 @@ class ControllerCacheService
         self::$cacheStore[$this->cacheFile] = [];
     }
 }
+

--- a/CorianderCore/core/Router/ViewRenderer.php
+++ b/CorianderCore/core/Router/ViewRenderer.php
@@ -26,7 +26,7 @@ class ViewRenderer
      */
     public function render(string $viewPath, array $data = []): bool
     {
-        $normalizedPath = $this->normalizeViewPath($viewPath);
+        $normalizedPath = SafePath::normalizeRelativePath($viewPath);
         if ($normalizedPath === null) {
             return false;
         }
@@ -78,31 +78,4 @@ class ViewRenderer
         return $data;
     }
 
-    /**
-     * Normalize and validate a view path to prevent traversal and invalid segments.
-     */
-    private function normalizeViewPath(string $viewPath): ?string
-    {
-        if (str_contains($viewPath, "\0")) {
-            return null;
-        }
-
-        $path = str_replace('\\', '/', trim($viewPath));
-        if ($path === '' || str_starts_with($path, '/')) {
-            return null;
-        }
-
-        if (preg_match('/^[a-zA-Z]:\//', $path) === 1) {
-            return null;
-        }
-
-        $segments = explode('/', trim($path, '/'));
-        foreach ($segments as $segment) {
-            if ($segment === '' || $segment === '.' || $segment === '..') {
-                return null;
-            }
-        }
-
-        return implode('/', $segments);
-    }
 }

--- a/CorianderCore/core/Security/ApiRequestLimitsMiddleware.php
+++ b/CorianderCore/core/Security/ApiRequestLimitsMiddleware.php
@@ -97,12 +97,15 @@ class ApiRequestLimitsMiddleware implements MiddlewareInterface
             return null;
         }
 
-        $currentPosition = $body->tell();
-        $body->seek(0, SEEK_END);
-        $endPosition = $body->tell();
-        $body->seek($currentPosition);
-
-        return $endPosition;
+        try {
+            $currentPosition = $body->tell();
+            $body->seek(0, SEEK_END);
+            $endPosition = $body->tell();
+            $body->seek($currentPosition);
+            return $endPosition;
+        } catch (\Throwable) {
+            return null;
+        }
     }
 
     private function isApiRequest(ServerRequestInterface $request): bool
@@ -136,4 +139,3 @@ class ApiRequestLimitsMiddleware implements MiddlewareInterface
         return new Response(413, ['Content-Type' => 'application/json; charset=utf-8'], $payload);
     }
 }
-

--- a/CorianderCore/core/Security/CsrfMiddleware.php
+++ b/CorianderCore/core/Security/CsrfMiddleware.php
@@ -89,7 +89,14 @@ class CsrfMiddleware implements MiddlewareInterface
         }
 
         $contentType = strtolower($request->getHeaderLine('Content-Type'));
-        $rawBody = (string) $request->getBody();
+        if (!str_contains($contentType, 'application/x-www-form-urlencoded') && !str_contains($contentType, 'application/json')) {
+            return null;
+        }
+
+        $rawBody = $this->readRequestBody($request);
+        if ($rawBody === '') {
+            return null;
+        }
 
         if (str_contains($contentType, 'application/x-www-form-urlencoded')) {
             $formBody = [];
@@ -106,11 +113,26 @@ class CsrfMiddleware implements MiddlewareInterface
             }
         }
 
-        if (isset($_POST['csrf_token']) && is_string($_POST['csrf_token'])) {
-            return $_POST['csrf_token'];
+        return null;
+    }
+
+    private function readRequestBody(ServerRequestInterface $request): string
+    {
+        $body = $request->getBody();
+
+        if (!$body->isSeekable()) {
+            return (string) $body;
         }
 
-        return null;
+        try {
+            $position = $body->tell();
+            $body->rewind();
+            $contents = $body->getContents();
+            $body->seek($position);
+            return $contents;
+        } catch (\Throwable) {
+            return (string) $body;
+        }
     }
 
     private function requiresValidation(string $method): bool

--- a/CorianderCore/tests/ApiControllerHandlerTest.php
+++ b/CorianderCore/tests/ApiControllerHandlerTest.php
@@ -136,6 +136,22 @@ class ApiControllerHandlerTest extends TestCase
         $this->assertSame('{"created":true}', (string) $response->getBody());
     }
 
+    public function testUsesInjectedControllerFactory(): void
+    {
+        $instantiated = [];
+        $handler = new ApiControllerHandler(
+            static function (string $className) use (&$instantiated): object {
+                $instantiated[] = $className;
+                return new $className();
+            }
+        );
+
+        $response = $handler->dispatch('api/sample/payload', 'GET');
+
+        $this->assertNotNull($response);
+        $this->assertSame(['ApiControllers\\SampleController'], $instantiated);
+    }
+
     /**
      * Ensure API controllers can be loaded from src/ApiControllers even when
      * they are not preloaded by autoload.
@@ -178,4 +194,3 @@ PHP
         }
     }
 }
-

--- a/CorianderCore/tests/BenchmarkHandlerTest.php
+++ b/CorianderCore/tests/BenchmarkHandlerTest.php
@@ -296,4 +296,9 @@ class BenchmarkHandlerTest extends TestCase
     //     $this->assertGreaterThan(0, $result['total_iterations'], "Total iterations should be greater than zero.");
     //     $this->assertGreaterThan(0, $result['average_iterations_per_second'], "Average iterations per second should be greater than zero.");
     // }
+    public function testCpuCoreCountIsAtLeastOne(): void
+    {
+        $this->assertGreaterThanOrEqual(1, $this->benchmarkHandler->getCpuCores());
+    }
 }
+

--- a/CorianderCore/tests/CsrfMiddlewareTest.php
+++ b/CorianderCore/tests/CsrfMiddlewareTest.php
@@ -202,4 +202,27 @@ class CsrfMiddlewareTest extends TestCase
 
         $this->assertSame(403, $response->getStatusCode());
     }
+
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testDoesNotUseGlobalPostFallback(): void
+    {
+        $token = Csrf::token();
+        $_POST['csrf_token'] = $token;
+
+        $middleware = new CsrfMiddleware(null, true);
+        $request = new ServerRequest('POST', '/test', ['Content-Type' => 'application/json'], '{}');
+        $handler = new class implements RequestHandlerInterface {
+            public bool $called = false;
+            public function handle(ServerRequestInterface $request): ResponseInterface
+            {
+                $this->called = true;
+                return new Response(200, [], 'OK');
+            }
+        };
+
+        $response = $middleware->process($request, $handler);
+
+        $this->assertFalse($handler->called);
+        $this->assertSame(403, $response->getStatusCode());
+    }
 }

--- a/CorianderCore/tests/ImageHandlerTest.php
+++ b/CorianderCore/tests/ImageHandlerTest.php
@@ -136,6 +136,6 @@ class ImageHandlerTest extends TestCase
 
         $this->assertStringContainsString('<picture class="picture-class">', $html, 'Picture tag was not rendered correctly.');
         $this->assertStringContainsString('<source srcset="/CorianderCore/tests/_tmp/assets/webp/test_image_80.webp" type="image/webp"', $html, 'WebP source tag was not rendered correctly.');
-        $this->assertStringContainsString('<img alt=\'Test Image\' width="100" height="100" class="img-class" src="/CorianderCore/tests/_tmp/assets/test_image.png"', $html, 'Image tag was not rendered correctly.');
+        $this->assertStringContainsString('<img alt="Test Image" width="100" height="100" class="img-class" src="/CorianderCore/tests/_tmp/assets/test_image.png"', $html, 'Image tag was not rendered correctly.');
     }
 }

--- a/CorianderCore/tests/ImageHandlerTest.php
+++ b/CorianderCore/tests/ImageHandlerTest.php
@@ -9,10 +9,10 @@ use CorianderCore\Core\Utils\DirectoryHandler;
 /**
  * Class ImageHandlerTest
  *
- * This test class verifies the functionality of the ImageHandler class, 
- * including converting images to WebP format and rendering a <picture> 
+ * This test class verifies the functionality of the ImageHandler class,
+ * including converting images to WebP format and rendering a <picture>
  * element with WebP and original image sources.
- * 
+ *
  * Requirements:
  * - PHP GD extension must be enabled to run the tests.
  * - The test will skip with a message if the GD extension is not available.
@@ -49,7 +49,7 @@ class ImageHandlerTest extends TestCase
         self::$testPath = PROJECT_ROOT . "/CorianderCore/tests/_tmp";
     }
 
-    
+
     protected function setUp(): void
     {
         // Check if GD extension is enabled
@@ -58,7 +58,7 @@ class ImageHandlerTest extends TestCase
                 'The GD extension is not enabled. Please enable it in your php.ini file. Current php.ini: ' . php_ini_loaded_file()
             );
         }
-        
+
         self::$testImageDir = self::$testPath . '/assets/';
         self::$testImagePath = '/CorianderCore/tests/_tmp/assets/test_image.png';
         self::$webpDir = 'webp/';
@@ -79,7 +79,7 @@ class ImageHandlerTest extends TestCase
             imagedestroy($image);
         }
     }
-    
+
     /**
      * tearDownAfterClass
      *
@@ -137,5 +137,19 @@ class ImageHandlerTest extends TestCase
         $this->assertStringContainsString('<picture class="picture-class">', $html, 'Picture tag was not rendered correctly.');
         $this->assertStringContainsString('<source srcset="/CorianderCore/tests/_tmp/assets/webp/test_image_80.webp" type="image/webp"', $html, 'WebP source tag was not rendered correctly.');
         $this->assertStringContainsString('<img alt="Test Image" width="100" height="100" class="img-class" src="/CorianderCore/tests/_tmp/assets/test_image.png"', $html, 'Image tag was not rendered correctly.');
+    }
+
+    public function testRejectsTraversalPaths(): void
+    {
+        $this->assertFalse(
+            ImageHandler::convertToWebP('/../../windows/system32/drivers/etc/hosts', 80),
+            'Traversal paths must be rejected.'
+        );
+
+        $this->assertSame(
+            '',
+            ImageHandler::render('/../../windows/system32/drivers/etc/hosts'),
+            'Render should return empty output for rejected traversal paths.'
+        );
     }
 }

--- a/CorianderCore/tests/RouterTest.php
+++ b/CorianderCore/tests/RouterTest.php
@@ -98,7 +98,7 @@ class RouterTest extends TestCase
         // Assert that the output contains expected content from the home page
         $this->assertStringContainsString('Installation Successful!', $output);
         // Assert that the requested view is correctly set to 'home'
-        $this->assertSame('home', REQUESTED_VIEW);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     /**
@@ -119,7 +119,7 @@ class RouterTest extends TestCase
         // Assert that the custom 404 message is displayed
         $this->assertStringContainsString('404 Custom Not Found', $output);
         // Assert that the requested view is correctly set to the non-existent route
-        $this->assertSame('non-existent-route', REQUESTED_VIEW);
+        $this->assertSame(404, $response->getStatusCode());
     }
 
     /**
@@ -140,7 +140,7 @@ class RouterTest extends TestCase
         // Assert that the output contains the correct content for the 'about' page
         $this->assertStringContainsString('About Page Content', $output);
         // Assert that the requested view is correctly set to 'about'
-        $this->assertSame('about', REQUESTED_VIEW);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
     /**
@@ -158,7 +158,7 @@ class RouterTest extends TestCase
         // Assert that the home page content is loaded by default
         $this->assertStringContainsString('Installation Successful!', $output);
         // Assert that the requested view is correctly set to 'home'
-        $this->assertSame('home', REQUESTED_VIEW);
+        $this->assertSame(200, $response->getStatusCode());
     }
 
 
@@ -179,7 +179,7 @@ class RouterTest extends TestCase
 
         $this->assertSame(404, $response->getStatusCode());
         $this->assertStringContainsString('404 Custom Not Found', $output);
-        $this->assertSame('home', REQUESTED_VIEW);
+        $this->assertSame(404, $response->getStatusCode());
     }
     /**
      * Test that the router handles a request to a controller where the action method does not exist.
@@ -466,4 +466,5 @@ PHP
         }
     }
 }
+
 

--- a/config/config.php
+++ b/config/config.php
@@ -9,6 +9,10 @@ if (!defined('PROJECT_URL')) {
 if (!defined('CORIANDER_UPDATE_BACKUP_DIR')) {
     define('CORIANDER_UPDATE_BACKUP_DIR', 'backups/coriander');
 }
+if (!defined('TRUSTED_PROXIES')) {
+    define('TRUSTED_PROXIES', getenv('TRUSTED_PROXIES') ?: '127.0.0.1,::1');
+}
+
 
 // Logging configuration via environment variables
 if (!defined('LOG_CHANNEL')) {
@@ -56,3 +60,4 @@ if (file_exists($databaseConfigFile)) {
     // Include the database configuration file
     include_once $databaseConfigFile;
 }
+

--- a/docs/routing.md
+++ b/docs/routing.md
@@ -55,7 +55,7 @@ $router->add('GET', '/profile', fn (ServerRequest $r) =>
 
 - Route callbacks and controller actions can return a `ResponseInterface`; status code, headers, and body are preserved.
 - API controller actions may return arrays, which are automatically encoded as JSON responses.
-- If an API action returns text output, it is returned with a JSON content type by default.
+- If an API action returns text output that is not valid JSON, it is wrapped as `{"data":"..."}` and returned as JSON.
 
 ## Error Handling
 
@@ -78,3 +78,4 @@ $router->add('POST', '/user', function(ServerRequest $request) {
 - Leverage PSR-15 middleware for cross-cutting concerns such as authentication or CSRF protection on mutating methods (`POST`, `PUT`, `PATCH`, `DELETE`).
 - Use URL parameters instead of query strings for cleaner, cache-friendly routes.
 - Avoid defining routes unless necessary; controllers are mapped automatically.
+

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,6 +18,13 @@ This page summarizes framework-level security behavior and recommended usage pat
 - Use `\CorianderCore\Core\Security\Csrf::input()` in forms.
 - For JSON/API requests, include token in JSON body as `csrf_token` when API enforcement is enabled (`CSRF_ENFORCE_API=1`).
 
+## Proxy and TLS Detection
+
+When CorianderPHP runs behind a reverse proxy/load balancer, HTTPS detection for secure cookies relies on `TRUSTED_PROXIES`.
+
+- `TRUSTED_PROXIES` accepts a comma-separated list of IPs/CIDRs (default: `127.0.0.1,::1`).
+- Proxy headers (`X-Forwarded-Proto`, `Forwarded`, etc.) are trusted only when `REMOTE_ADDR` matches this allowlist.
+- Example: `TRUSTED_PROXIES=127.0.0.1,::1,10.0.0.0/8,192.168.0.0/16`
 ## Response Security Headers
 
 `SecurityHeadersMiddleware` is enabled by default and injects a secure baseline:
@@ -78,4 +85,5 @@ CorianderPHP hardens framework-level defaults, but application code remains resp
 - authorization checks
 - output encoding in non-framework rendering paths
 - secure secret management and environment configuration
+
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -14,9 +14,9 @@ This page summarizes framework-level security behavior and recommended usage pat
 
 ## CSRF Protection
 
-- CSRF middleware validates mutating methods: `POST`, `PUT`, `PATCH`, `DELETE`.
+- CSRF middleware validates mutating methods: `POST`, `PUT`, `PATCH`, `DELETE` (except `/api/*` by default).
 - Use `\CorianderCore\Core\Security\Csrf::input()` in forms.
-- For JSON/API requests, include token in JSON body as `csrf_token`.
+- For JSON/API requests, include token in JSON body as `csrf_token` when API enforcement is enabled (`CSRF_ENFORCE_API=1`).
 
 ## Response Security Headers
 
@@ -78,3 +78,4 @@ CorianderPHP hardens framework-level defaults, but application code remains resp
 - authorization checks
 - output encoding in non-framework rendering paths
 - secure secret management and environment configuration
+

--- a/public/index.php
+++ b/public/index.php
@@ -16,6 +16,70 @@ use Nyholm\Psr7\ServerRequest;
  *
  * Supports direct HTTPS and common reverse proxy headers.
  */
+function corianderIpInCidr(string $ip, string $cidr): bool
+{
+    if (!str_contains($cidr, '/')) {
+        return $ip === $cidr;
+    }
+
+    [$subnet, $prefixLength] = explode('/', $cidr, 2);
+    if ($subnet === '' || !ctype_digit($prefixLength)) {
+        return false;
+    }
+
+    $ipBinary = @inet_pton($ip);
+    $subnetBinary = @inet_pton($subnet);
+    if ($ipBinary === false || $subnetBinary === false || strlen($ipBinary) !== strlen($subnetBinary)) {
+        return false;
+    }
+
+    $bits = (int) $prefixLength;
+    $maxBits = strlen($ipBinary) * 8;
+    if ($bits < 0 || $bits > $maxBits) {
+        return false;
+    }
+
+    $bytes = intdiv($bits, 8);
+    $remainder = $bits % 8;
+
+    if ($bytes > 0 && substr($ipBinary, 0, $bytes) !== substr($subnetBinary, 0, $bytes)) {
+        return false;
+    }
+
+    if ($remainder === 0) {
+        return true;
+    }
+
+    $mask = (0xFF << (8 - $remainder)) & 0xFF;
+    return (ord($ipBinary[$bytes]) & $mask) === (ord($subnetBinary[$bytes]) & $mask);
+}
+
+function corianderIsTrustedProxy(string $remoteAddr): bool
+{
+    if ($remoteAddr === '') {
+        return false;
+    }
+
+    $trusted = defined('TRUSTED_PROXIES') ? (string) TRUSTED_PROXIES : '127.0.0.1,::1';
+    $entries = array_map(static fn(string $item): string => trim($item), explode(',', $trusted));
+
+    foreach ($entries as $entry) {
+        if ($entry === '') {
+            continue;
+        }
+
+        if ($entry === '*') {
+            return true;
+        }
+
+        if (corianderIpInCidr($remoteAddr, $entry)) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
 function corianderIsSecureRequest(array $serverParams): bool
 {
     $https = strtolower((string) ($serverParams['HTTPS'] ?? ''));
@@ -24,15 +88,18 @@ function corianderIsSecureRequest(array $serverParams): bool
     }
 
     $remoteAddr = (string) ($serverParams['REMOTE_ADDR'] ?? '');
-    $trustedProxy = in_array($remoteAddr, ['127.0.0.1', '::1'], true);
-
-    if ($trustedProxy) {
+    if (corianderIsTrustedProxy($remoteAddr)) {
         $forwardedProto = strtolower((string) ($serverParams['HTTP_X_FORWARDED_PROTO'] ?? ''));
         if ($forwardedProto !== '') {
             $firstHop = trim(explode(',', $forwardedProto, 2)[0]);
             if ($firstHop === 'https') {
                 return true;
             }
+        }
+
+        $forwarded = strtolower((string) ($serverParams['HTTP_FORWARDED'] ?? ''));
+        if ($forwarded !== '' && str_contains($forwarded, 'proto=https')) {
+            return true;
         }
 
         $forwardedSsl = strtolower((string) ($serverParams['HTTP_X_FORWARDED_SSL'] ?? ''));
@@ -49,6 +116,8 @@ function corianderIsSecureRequest(array $serverParams): bool
     return (string) ($serverParams['SERVER_PORT'] ?? '') === '443';
 }
 
+require_once '../config/config.php';
+
 $secure = corianderIsSecureRequest($_SERVER);
 session_set_cookie_params([
     'path' => '/',
@@ -57,8 +126,6 @@ session_set_cookie_params([
     'samesite' => 'Lax',
 ]);
 session_start();
-
-require_once '../config/config.php';
 
 if (file_exists(PROJECT_ROOT . '/CorianderCore/autoload.php')) {
     require_once PROJECT_ROOT . '/CorianderCore/autoload.php';
@@ -156,4 +223,5 @@ try {
 
     echo 'Internal Server Error';
 }
+
 

--- a/public/index.php
+++ b/public/index.php
@@ -116,6 +116,26 @@ function corianderIsSecureRequest(array $serverParams): bool
     return (string) ($serverParams['SERVER_PORT'] ?? '') === '443';
 }
 
+
+function corianderCreateNotFoundHandler(): callable
+{
+    return static function (): Response {
+        $notFoundView = 'notfound';
+
+        $metaDataFile = PROJECT_ROOT . '/public/public_views/' . $notFoundView . '/metadata.php';
+
+        if (file_exists($metaDataFile)) {
+            include $metaDataFile;
+        }
+
+        ob_start();
+        require_once PROJECT_ROOT . '/public/public_views/header.php';
+        require_once PROJECT_ROOT . '/public/public_views/' . $notFoundView . '/index.php';
+        require_once PROJECT_ROOT . '/public/public_views/footer.php';
+
+        return new Response(404, [], (string) ob_get_clean());
+    };
+}
 require_once '../config/config.php';
 
 $secure = corianderIsSecureRequest($_SERVER);
@@ -149,23 +169,7 @@ try {
     $router->addMiddleware(new ApiRequestLimitsMiddleware());
     $router->addMiddleware(new CsrfMiddleware());
 
-    $notFound = function () {
-        $notFoundView = 'notfound';
-
-        $metaDataFile = PROJECT_ROOT . '/public/public_views/' . $notFoundView . '/metadata.php';
-
-        if (file_exists($metaDataFile)) {
-            include $metaDataFile;
-        }
-
-        ob_start();
-        require_once PROJECT_ROOT . '/public/public_views/header.php';
-        require_once PROJECT_ROOT . '/public/public_views/' . $notFoundView . '/index.php';
-        require_once PROJECT_ROOT . '/public/public_views/footer.php';
-
-        return new Response(404, [], (string) ob_get_clean());
-    };
-    $router->setNotFound($notFound);
+    $router->setNotFound(corianderCreateNotFoundHandler());
 
     $routesFile = __DIR__ . '/routes.php';
     if (file_exists($routesFile)) {
@@ -223,5 +227,6 @@ try {
 
     echo 'Internal Server Error';
 }
+
 
 

--- a/readme.md
+++ b/readme.md
@@ -115,6 +115,8 @@ CorianderPHP ships with a token-based CSRF guard. Include the token inside forms
 
 Controllers validate tokens using `Csrf::validateRequest()` or `Csrf::validate()` for JSON payloads. By default, middleware validation applies to mutating web methods (`POST`, `PUT`, `PATCH`, `DELETE`) and accepts tokens from parsed bodies and standard `application/x-www-form-urlencoded`/`application/json` request bodies. API routes are excluded unless `CSRF_ENFORCE_API=1`.
 
+Behind a reverse proxy, configure TRUSTED_PROXIES so secure-cookie HTTPS detection trusts only known proxy addresses.
+
 ## Development Status
 
 CorianderPHP is under active development. Check the documentation for the latest features and updates.
@@ -126,4 +128,5 @@ We welcome contributions. Please submit pull requests or report issues on GitHub
 ## License
 
 This project is licensed under the MIT License.
+
 

--- a/readme.md
+++ b/readme.md
@@ -113,7 +113,7 @@ CorianderPHP ships with a token-based CSRF guard. Include the token inside forms
 </form>
 ```
 
-Controllers validate tokens using `Csrf::validateRequest()` or `Csrf::validate()` for JSON payloads. By default, middleware validation applies to mutating methods (`POST`, `PUT`, `PATCH`, `DELETE`) and accepts tokens from parsed bodies and standard `application/x-www-form-urlencoded`/`application/json` request bodies.
+Controllers validate tokens using `Csrf::validateRequest()` or `Csrf::validate()` for JSON payloads. By default, middleware validation applies to mutating web methods (`POST`, `PUT`, `PATCH`, `DELETE`) and accepts tokens from parsed bodies and standard `application/x-www-form-urlencoded`/`application/json` request bodies. API routes are excluded unless `CSRF_ENFORCE_API=1`.
 
 ## Development Status
 
@@ -126,3 +126,4 @@ We welcome contributions. Please submit pull requests or report issues on GitHub
 ## License
 
 This project is licensed under the MIT License.
+


### PR DESCRIPTION
## PR Title
Security hardening, SOLID/DRY refactors, and reliability improvements across core framework

## Summary
This PR consolidates a full framework audit pass (plus follow-up passes) and applies fixes across security, performance, SOLID/DRY design, tests, and docs.

Main goals:
- Remove high-risk security gaps (path traversal, proxy trust, unsafe globals, weak request handling)
- Improve architecture (dependency inversion + deduplication)
- Reduce runtime fragility and shell dependence
- Align tests/docs with hardened behavior

## What Changed

### Security fixes
- Escaped image HTML attributes to prevent XSS.
- Hardened HTTPS detection with trusted-proxy support.
- Hardened image path handling to reject traversal and unsafe paths.
- Removed CSRF middleware fallback to global `$_POST`; now request-scoped extraction only.
- Guarded API request-size middleware against seek/tell stream failures.
- Hardened SQL identifier quoting:
  - Reject empty/invalid identifier segments.
  - Properly support dotted identifiers.
- Sanitized updater backup scopes to block traversal and out-of-scope writes.

### SOLID / DRY refactors
- Injected controller factories in handlers (improves DIP/testability).
- Deduplicated action visibility checks via shared inspector.
- Centralized safe relative-path normalization.
- Extracted not-found handler factory from front controller.
- Removed remaining global requested-view state coupling.

### Performance / reliability
- Made controller cache writes atomic/safer.
- Cached timezone identifier lookups.
- Replaced shell-based CPU core detection with safe PHP-only paths.
- Added zero/edge guards in benchmark math.

### API behavior hardening
- Enforced valid JSON payload behavior for API responses.
- Updated API text response docs accordingly.

### Docs and tests
- Added and updated regression tests for all new hardening paths:
  - image traversal
  - CSRF body parsing/global fallback removal
  - API stream edge handling
  - SQL identifier edge cases
  - updater backup-scope traversal
- Documentation updates:
  - CSRF default API behavior
  - trusted proxy configuration (`TRUSTED_PROXIES`)
  - API response behavior notes

## Validation
- Full test suite passes:
  - `OK (142 tests, 302 assertions)`

## Notes for reviewers
- No destructive migrations required.
- Behavior is stricter by design in security-sensitive areas (invalid/traversal paths and malformed identifiers now fail fast).
- Proxy deployments should verify `TRUSTED_PROXIES` is configured correctly.
