### PR TITLE
Fix windows npm resolution

### DIFF
--- a/CorianderCore/Tests/NodeJSTest.php
+++ b/CorianderCore/Tests/NodeJSTest.php
@@ -4,10 +4,30 @@ declare(strict_types=1);
 namespace CorianderCore\Tests;
 
 use CorianderCore\Core\Console\Commands\NodeJS;
+use CorianderCore\Core\Console\Services\Node\NpmExecutableResolver;
 use PHPUnit\Framework\TestCase;
 
 class NodeJSTest extends TestCase
 {
+    private ?string $previousCorianderNpmExecutable = null;
+    private ?string $previousNpmExecutable = null;
+
+    protected function setUp(): void
+    {
+        $this->previousCorianderNpmExecutable = getenv('CORIANDER_NPM_EXECUTABLE') === false
+            ? null
+            : (string) getenv('CORIANDER_NPM_EXECUTABLE');
+        $this->previousNpmExecutable = getenv('NPM_EXECUTABLE') === false
+            ? null
+            : (string) getenv('NPM_EXECUTABLE');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->restoreEnvironment('CORIANDER_NPM_EXECUTABLE', $this->previousCorianderNpmExecutable);
+        $this->restoreEnvironment('NPM_EXECUTABLE', $this->previousNpmExecutable);
+    }
+
     public function testExecuteWithoutArgsPrintsError(): void
     {
         $command = new NodeJS();
@@ -30,5 +50,70 @@ class NodeJSTest extends TestCase
         $this->assertStringContainsString('Starting watcher... Press Ctrl+C to stop.', $output);
         $this->assertStringContainsString('Could not open input file', $output);
         $this->assertStringContainsString('npm command failed with exit code', $output);
+    }
+
+    public function testResolveNpmExecutableUsesEnvironmentOverride(): void
+    {
+        putenv('CORIANDER_NPM_EXECUTABLE=C:\Tools\nodejs\npm.cmd');
+        putenv('NPM_EXECUTABLE');
+
+        $resolver = new NpmExecutableResolver();
+
+        $this->assertSame('C:\Tools\nodejs\npm.cmd', $resolver->resolve());
+    }
+
+    public function testResolveNpmExecutableSkipsBrokenNodeSiblingNpm(): void
+    {
+        if (DIRECTORY_SEPARATOR !== '\\') {
+            $this->markTestSkipped('Windows npm resolution is only used on Windows.');
+        }
+
+        $root = sys_get_temp_dir() . '/coriander-nodejs-' . bin2hex(random_bytes(4));
+        $brokenNodeDir = $root . '/broken-node';
+        $validNodeDir = $root . '/valid-node';
+        mkdir($brokenNodeDir, 0777, true);
+        mkdir($validNodeDir . '/node_modules/npm/bin', 0777, true);
+
+        $brokenNode = $brokenNodeDir . DIRECTORY_SEPARATOR . 'node.exe';
+        $brokenNpm = $brokenNodeDir . DIRECTORY_SEPARATOR . 'npm.cmd';
+        $validNode = $validNodeDir . DIRECTORY_SEPARATOR . 'node.exe';
+        $validNpm = $validNodeDir . DIRECTORY_SEPARATOR . 'npm.cmd';
+        $validNpmCli = $validNodeDir . DIRECTORY_SEPARATOR . 'node_modules/npm/bin/npm-cli.js';
+
+        touch($brokenNode);
+        touch($brokenNpm);
+        touch($validNode);
+        touch($validNpm);
+        touch($validNpmCli);
+
+        try {
+            $resolver = new NpmExecutableResolver(null, static fn(string $name): array => $name === 'node'
+                ? [$brokenNode, $validNode]
+                : [$brokenNpm, $validNpm]);
+
+            $this->assertSame($validNpm, $resolver->resolve());
+        } finally {
+            @unlink($validNpmCli);
+            @unlink($validNpm);
+            @unlink($validNode);
+            @unlink($brokenNpm);
+            @unlink($brokenNode);
+            @rmdir($validNodeDir . '/node_modules/npm/bin');
+            @rmdir($validNodeDir . '/node_modules/npm');
+            @rmdir($validNodeDir . '/node_modules');
+            @rmdir($validNodeDir);
+            @rmdir($brokenNodeDir);
+            @rmdir($root);
+        }
+    }
+
+    private function restoreEnvironment(string $name, ?string $value): void
+    {
+        if ($value === null) {
+            putenv($name);
+            return;
+        }
+
+        putenv($name . '=' . $value);
     }
 }

--- a/CorianderCore/core/Console/Commands/NodeJS.php
+++ b/CorianderCore/core/Console/Commands/NodeJS.php
@@ -9,11 +9,15 @@ declare(strict_types=1);
 namespace CorianderCore\Core\Console\Commands;
 
 use CorianderCore\Core\Console\ConsoleOutput;
+use CorianderCore\Core\Console\Services\Node\NpmExecutableResolver;
 
 class NodeJS
 {
-    public function __construct(private ?string $npmExecutableOverride = null)
+    private NpmExecutableResolver $npmExecutableResolver;
+
+    public function __construct(?string $npmExecutableOverride = null, ?callable $executableLocator = null)
     {
+        $this->npmExecutableResolver = new NpmExecutableResolver($npmExecutableOverride, $executableLocator);
     }
 
     /**
@@ -39,7 +43,8 @@ class NodeJS
             ConsoleOutput::print('&2Starting watcher...&7 Press Ctrl+C to stop.');
         }
 
-        $command = array_merge([$this->resolveNpmExecutable()], array_values($args));
+        $npmExecutable = $this->resolveNpmExecutable();
+        $command = array_merge([$npmExecutable], array_values($args));
 
         $descriptors = [
             0 => ['pipe', 'r'],
@@ -65,6 +70,7 @@ class NodeJS
         $exitCode = proc_close($process);
         if ($exitCode !== 0) {
             ConsoleOutput::print('&4[Error]&7 npm command failed with exit code ' . (string) $exitCode . '.');
+            ConsoleOutput::print('&8|&7 Resolved npm executable: ' . $npmExecutable);
         }
     }
 
@@ -126,31 +132,6 @@ class NodeJS
 
     private function resolveNpmExecutable(): string
     {
-        if (is_string($this->npmExecutableOverride) && trim($this->npmExecutableOverride) !== '') {
-            return $this->npmExecutableOverride;
-        }
-
-        if (DIRECTORY_SEPARATOR !== '\\') {
-            return 'npm';
-        }
-
-        $candidates = [];
-        $programFiles = getenv('ProgramFiles');
-        if (is_string($programFiles) && $programFiles !== '') {
-            $candidates[] = rtrim($programFiles, '\\/') . '\\nodejs\\npm.cmd';
-        }
-
-        $programFilesX86 = getenv('ProgramFiles(x86)');
-        if (is_string($programFilesX86) && $programFilesX86 !== '') {
-            $candidates[] = rtrim($programFilesX86, '\\/') . '\\nodejs\\npm.cmd';
-        }
-
-        foreach ($candidates as $candidate) {
-            if (is_file($candidate)) {
-                return $candidate;
-            }
-        }
-
-        return 'npm.cmd';
+        return $this->npmExecutableResolver->resolve();
     }
 }

--- a/CorianderCore/core/Console/Services/Node/NpmExecutableResolver.php
+++ b/CorianderCore/core/Console/Services/Node/NpmExecutableResolver.php
@@ -1,0 +1,150 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Core\Console\Services\Node;
+
+/**
+ * Resolves the npm launcher in a way that avoids project-local Windows shims.
+ */
+class NpmExecutableResolver
+{
+    /**
+     * @var callable(string):array<int,string>|null
+     */
+    private $executableLocator;
+
+    public function __construct(private ?string $executableOverride = null, ?callable $executableLocator = null)
+    {
+        $this->executableLocator = $executableLocator;
+    }
+
+    public function resolve(): string
+    {
+        if (is_string($this->executableOverride) && trim($this->executableOverride) !== '') {
+            return trim($this->executableOverride);
+        }
+
+        $environmentOverride = $this->resolveEnvironmentOverride();
+        if ($environmentOverride !== null) {
+            return $environmentOverride;
+        }
+
+        if (DIRECTORY_SEPARATOR !== '\\') {
+            return 'npm';
+        }
+
+        foreach ($this->windowsCandidates() as $candidate) {
+            if ($this->isUsableNpmExecutable($candidate)) {
+                return $candidate;
+            }
+        }
+
+        return 'npm.cmd';
+    }
+
+    private function resolveEnvironmentOverride(): ?string
+    {
+        foreach (['CORIANDER_NPM_EXECUTABLE', 'NPM_EXECUTABLE'] as $name) {
+            $value = getenv($name);
+            if (is_string($value) && trim($value) !== '') {
+                return trim($value);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private function windowsCandidates(): array
+    {
+        $candidates = [];
+
+        foreach ($this->locateExecutable('node') as $nodeExecutable) {
+            if (is_file($nodeExecutable)) {
+                $candidates[] = dirname($nodeExecutable) . '\\npm.cmd';
+            }
+        }
+
+        foreach (['ProgramFiles', 'ProgramFiles(x86)'] as $environmentName) {
+            $path = getenv($environmentName);
+            if (is_string($path) && $path !== '') {
+                $candidates[] = rtrim($path, '\\/') . '\\nodejs\\npm.cmd';
+            }
+        }
+
+        foreach ($this->locateExecutable('npm') as $npmExecutable) {
+            $candidates[] = $npmExecutable;
+        }
+
+        return array_values(array_unique($candidates));
+    }
+
+    /**
+     * @return array<int,string>
+     */
+    private function locateExecutable(string $name): array
+    {
+        if ($this->executableLocator !== null) {
+            $locator = $this->executableLocator;
+            $located = $locator($name);
+
+            return is_array($located)
+                ? $this->normalizeExecutableList($located)
+                : [];
+        }
+
+        if (DIRECTORY_SEPARATOR !== '\\') {
+            return [];
+        }
+
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        $process = @proc_open(['where.exe', $name], $descriptors, $pipes);
+        if (!is_resource($process)) {
+            return [];
+        }
+
+        fclose($pipes[0]);
+        $output = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        if (proc_close($process) !== 0 || !is_string($output)) {
+            return [];
+        }
+
+        return $this->normalizeExecutableList(preg_split('/\R/', $output) ?: []);
+    }
+
+    /**
+     * @param array<int,mixed> $paths
+     * @return array<int,string>
+     */
+    private function normalizeExecutableList(array $paths): array
+    {
+        return array_values(array_filter(
+            array_map(static fn(mixed $path): string => is_string($path) ? trim($path) : '', $paths),
+            static fn(string $path): bool => $path !== ''
+        ));
+    }
+
+    private function isUsableNpmExecutable(string $candidate): bool
+    {
+        $candidate = trim($candidate, "\" \t\n\r\0\x0B");
+        if ($candidate === '' || !is_file($candidate)) {
+            return false;
+        }
+
+        if (strtolower(substr($candidate, -4)) !== '.cmd') {
+            return true;
+        }
+
+        return is_file(dirname($candidate) . '\\node_modules\\npm\\bin\\npm-cli.js');
+    }
+}

--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -2,6 +2,36 @@
 
 CorianderPHP provides NodeJS tooling for compiling TypeScript and TailwindCSS assets.
 
+## Requirements
+
+Install Node.js with npm before using the NodeJS commands. On Windows, the official
+installer usually provides npm at:
+
+```powershell
+C:\Program Files\nodejs\npm.cmd
+```
+
+If you use a portable or custom Node.js installation, make sure npm is included and
+available from your shell. You can verify which npm executable is used with:
+
+```powershell
+where.exe npm
+Get-Command npm -All
+```
+
+With the official Windows installer, npm is normally found under
+`C:\Program Files\nodejs\`. A portable installation should resolve npm from the
+portable Node.js directory, for example:
+
+```text
+F:\dev\nodejs\npm.cmd
+```
+
+The exact internal npm files can vary between Node.js/npm versions. Do not rely
+on internal paths such as `node_modules\npm\bin\npm-cli.js` for normal setup
+checks. Instead, verify that `npm -v` works and that `where.exe npm` or
+`Get-Command npm -All` points first to the Node.js installation you intend to use.
+
 ## Installing Dependencies
 
 Install packages defined in `package.json`:
@@ -15,6 +45,11 @@ Add a new package (e.g. `axios`):
 ```bash
 php coriander nodejs install axios
 ```
+
+Coriander runs npm internally from the project `nodejs/` directory, so the command
+above is equivalent to running `npm install` there. Do not include `npm` in the
+Coriander command; `php coriander nodejs npm install` would try to run
+`npm npm install`.
 
 ## Available Scripts
 
@@ -57,4 +92,35 @@ Run all commands from the project root.
 - Commit only compiled assets needed for production; ignore `node_modules/`.
 - Run `install` after pulling changes to ensure packages are up to date.
 - For troubleshooting, run the underlying npm command directly inside the `nodejs` directory.
+
+## Troubleshooting Windows npm Resolution
+
+Coriander resolves npm automatically. If a custom or portable Node.js installation
+causes npm to resolve incorrectly, point Coriander to the npm launcher explicitly:
+
+```powershell
+$env:CORIANDER_NPM_EXECUTABLE = "C:\Program Files\nodejs\npm.cmd"
+php coriander nodejs install
+```
+
+You can also use `NPM_EXECUTABLE` if you already rely on that environment variable:
+
+```powershell
+$env:NPM_EXECUTABLE = "C:\Program Files\nodejs\npm.cmd"
+php coriander nodejs install
+```
+
+Inspect the executables found by your shell:
+
+```powershell
+where.exe node
+where.exe npm
+Get-Command npm -All
+```
+
+If npm fails with a path like `project\nodejs\node_modules\npm\bin\npm-cli.js`,
+the npm launcher is probably resolving npm internals relative to the project
+directory instead of the Node.js installation. Check the first result from
+`where.exe npm`, repair the Node.js installation if needed, or set
+`CORIANDER_NPM_EXECUTABLE` to the intended `npm.cmd` path.
 

--- a/readme.md
+++ b/readme.md
@@ -47,6 +47,9 @@ These guides are kept in sync with releases; review them when upgrading.
    php coriander nodejs install             # install from package.json
    php coriander nodejs install tailwindcss # add a package
    ```
+   Requires Node.js with npm available. On Windows, npm is usually installed at
+   `C:\Program Files\nodejs\npm.cmd`; custom installs can be configured with
+   `CORIANDER_NPM_EXECUTABLE` (see [NodeJS Integration](docs/nodejs.md)).
 4. Watch or build assets as needed (see [NodeJS Integration](docs/nodejs.md)).
 
 ### Logging


### PR DESCRIPTION
## Summary
- Add a dedicated npm executable resolver for the NodeJS console command
- Prefer explicit `CORIANDER_NPM_EXECUTABLE` / `NPM_EXECUTABLE` overrides
- On Windows, prefer valid npm launchers beside the resolved `node.exe`
- Skip broken `npm.cmd` shims when npm's CLI file is missing
- Print the resolved npm executable when npm exits with an error
- Update readme.md

## Why
Some Windows setups, especially portable/custom Node installs, can resolve a broken `npm.cmd` that looks for npm inside the project `nodejs/node_modules/npm` directory. This fails before `npm install` can run.

Resolving and validating npm before execution makes the command more robust and gives users clearer diagnostics.

## Tests
- `vendor\bin\phpunit --testdox CorianderCore\Tests\NodeJSTest.php`
- `vendor\bin\phpunit --testdox`
- `composer validate --strict --no-check-publish`