### PR TITLE
Improve routing fallback and NodeJS watcher workflow

### DIFF
--- a/docs/nodejs.md
+++ b/docs/nodejs.md
@@ -59,6 +59,10 @@ Run all commands from the project root.
   ```bash
   php coriander nodejs run watch-ts
   ```
+- **Watch TypeScript and TailwindCSS**
+  ```bash
+  php coriander nodejs run watch-all
+  ```
 - **Build TypeScript**
   ```bash
   php coriander nodejs run build-ts

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "watch-typescript": "tsc --watch",
     "build-typescript": "tsc",
+    "watch-all": "node watch.all.js",
     "watch-ts": "node build.watch.js",
     "build-ts": "node build.js",
     "watch-tw": "tailwindcss -i ../public/assets/css/input.css -o ../public/assets/css/output.css --watch=always --minify",

--- a/nodejs/watch.all.js
+++ b/nodejs/watch.all.js
@@ -1,0 +1,77 @@
+import { spawn } from 'child_process';
+import path from 'path';
+
+const isWindows = process.platform === 'win32';
+const tailwindBinary = path.join(
+  'node_modules',
+  '.bin',
+  isWindows ? 'tailwindcss.cmd' : 'tailwindcss',
+);
+
+let shuttingDown = false;
+
+const watchers = [
+  ['watch-ts', process.execPath, ['build.watch.js'], false],
+  [
+    'watch-tw',
+    tailwindBinary,
+    [
+      '-i',
+      '../public/assets/css/input.css',
+      '-o',
+      '../public/assets/css/output.css',
+      '--watch=always',
+      '--minify',
+    ],
+    isWindows,
+  ],
+];
+
+const children = watchers.map(([label, command, args, shell]) => {
+  const child = spawn(command, args, {
+    stdio: ['inherit', 'pipe', 'pipe'],
+    shell,
+  });
+
+  child.stdout.on('data', chunk => {
+    process.stdout.write(`[${label}] ${chunk}`);
+  });
+
+  child.stderr.on('data', chunk => {
+    process.stderr.write(`[${label}] ${chunk}`);
+  });
+
+  child.on('error', error => {
+    console.error(`[${label}] failed to start: ${error.message}`);
+    stopWatchers(1);
+  });
+
+  child.on('exit', code => {
+    if (code === 0 || shuttingDown) {
+      return;
+    }
+
+    console.error(`[${label}] exited with code ${code}. Stopping watchers.`);
+    stopWatchers(code ?? 1);
+  });
+
+  return child;
+});
+
+function stopWatchers(exitCode = 0) {
+  if (shuttingDown) {
+    return;
+  }
+
+  shuttingDown = true;
+  for (const child of children) {
+    if (!child.killed) {
+      child.kill();
+    }
+  }
+
+  process.exitCode = exitCode;
+}
+
+process.on('SIGINT', () => stopWatchers(0));
+process.on('SIGTERM', () => stopWatchers(0));

--- a/public/index.php
+++ b/public/index.php
@@ -169,7 +169,8 @@ try {
     $router->addMiddleware(new ApiRequestLimitsMiddleware());
     $router->addMiddleware(new CsrfMiddleware());
 
-    $router->setNotFound(corianderCreateNotFoundHandler());
+    $notFound = corianderCreateNotFoundHandler();
+    $router->setNotFound($notFound);
 
     $routesFile = __DIR__ . '/routes.php';
     if (file_exists($routesFile)) {


### PR DESCRIPTION
## Summary
- Fix `$notFound` availability for custom route files loaded by `public/index.php`
- Add `php coriander nodejs run watch-all` to watch TypeScript and TailwindCSS in one terminal
- Document the new combined watcher command

## Details
`public/routes.php` documents access to `$router` and `$notFound`, but the front controller only registered the not-found handler on the router. This now assigns the handler to `$notFound` before loading route files.

The new `watch-all` npm script runs the existing TypeScript watcher and Tailwind watcher together without adding a new dependency.

## Tests
- `php -l public\index.php`
- `vendor\bin\phpunit --testdox CorianderCore\Tests\RouterTest.php CorianderCore\Tests\RouterIntegrationTest.php CorianderCore\Tests\RouteDispatcherTest.php`
- `node --check nodejs\watch.all.js`
- `npm.cmd --prefix nodejs run`

## Compatibility
No breaking changes.
Existing `watch-ts` and `watch-tw` commands are unchanged.