### PR TITLE
Harden output buffer cleanup during dispatch

### DIFF
--- a/CorianderCore/Tests/RouteDispatcherTest.php
+++ b/CorianderCore/Tests/RouteDispatcherTest.php
@@ -61,4 +61,25 @@ class RouteDispatcherTest extends TestCase
         $this->assertSame(404, $response->getStatusCode());
         $this->assertSame('missing', (string) $response->getBody());
     }
+
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testCustomRouteExceptionCleansOutputBuffer(): void
+    {
+        $router = new Router();
+        $router->add('GET', '/throws', function (ServerRequest $request): void {
+            echo 'partial output';
+            throw new \RuntimeException('Route failed.');
+        });
+
+        $bufferLevel = ob_get_level();
+
+        try {
+            $router->dispatch(new ServerRequest('GET', '/throws'));
+            $this->fail('Expected route exception to be thrown.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('Route failed.', $exception->getMessage());
+        }
+
+        $this->assertSame($bufferLevel, ob_get_level());
+    }
 }

--- a/CorianderCore/core/Router/Handlers/ApiControllerHandler.php
+++ b/CorianderCore/core/Router/Handlers/ApiControllerHandler.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace CorianderCore\Core\Router\Handlers;
 
 use CorianderCore\Core\Router\NameFormatter;
+use CorianderCore\Core\Support\OutputBuffer;
 use Nyholm\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
 
@@ -67,9 +68,7 @@ class ApiControllerHandler
             return null;
         }
 
-        ob_start();
-        $result = call_user_func_array([$controller, $action], $params);
-        $content = (string) ob_get_clean();
+        [$result, $content] = OutputBuffer::capture(fn() => call_user_func_array([$controller, $action], $params));
 
         if ($result instanceof ResponseInterface) {
             return $result;

--- a/CorianderCore/core/Router/Handlers/WebControllerHandler.php
+++ b/CorianderCore/core/Router/Handlers/WebControllerHandler.php
@@ -5,6 +5,7 @@ namespace CorianderCore\Core\Router\Handlers;
 
 use CorianderCore\Core\Router\NameFormatter;
 use CorianderCore\Core\Router\Services\ControllerCacheService;
+use CorianderCore\Core\Support\OutputBuffer;
 use Nyholm\Psr7\Response;
 use Psr\Http\Message\ResponseInterface;
 
@@ -70,9 +71,13 @@ class WebControllerHandler
         $factory = $this->controllerFactory;
         $controller = $factory($controllerClass);
 
-        ob_start();
-        [$handled, $result] = $this->dispatchAction($controller, $segments, $method);
-        $content = (string) ob_get_clean();
+        [$handledAndResult, $content] = OutputBuffer::capture(function () use ($controller, $segments, $method): array {
+            [$handled, $result] = $this->dispatchAction($controller, $segments, $method);
+
+            return [$handled, $result];
+        });
+
+        [$handled, $result] = $handledAndResult;
 
         if (!$handled) {
             return null;

--- a/CorianderCore/core/Router/RouteDispatcher.php
+++ b/CorianderCore/core/Router/RouteDispatcher.php
@@ -6,6 +6,7 @@ namespace CorianderCore\Core\Router;
 use CorianderCore\Core\Router\Handlers\ApiControllerHandler;
 use CorianderCore\Core\Router\Handlers\NotFoundHandler;
 use CorianderCore\Core\Router\Handlers\WebControllerHandler;
+use CorianderCore\Core\Support\OutputBuffer;
 use CorianderCore\Core\Router\ViewRenderer;
 use CorianderCore\Core\Router\Middleware\MiddlewareQueue;
 use Nyholm\Psr7\Response;
@@ -66,9 +67,8 @@ class RouteDispatcher
 
                 public function handle(ServerRequestInterface $request): ResponseInterface
                 {
-                    ob_start();
-                    $result = call_user_func($this->callback, $request);
-                    $content = (string) ob_get_clean();
+                    [$result, $content] = OutputBuffer::capture(fn() => call_user_func($this->callback, $request));
+
                     if ($result instanceof ResponseInterface) {
                         return $result;
                     }
@@ -104,13 +104,11 @@ class RouteDispatcher
             return $webResponse;
         }
 
-        ob_start();
-        if ($this->viewRenderer->render($path)) {
-            $content = (string) ob_get_clean();
+        [$rendered, $content] = OutputBuffer::capture(fn() => $this->viewRenderer->render($path));
+        if ($rendered) {
             return new Response(200, [], $content);
         }
 
-        ob_end_clean();
         return $this->notFoundHandler->handle($this->registry);
     }
 

--- a/CorianderCore/core/Support/OutputBuffer.php
+++ b/CorianderCore/core/Support/OutputBuffer.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Core\Support;
+
+final class OutputBuffer
+{
+    /**
+     * Capture output emitted while running user code.
+     *
+     * @return array{0:mixed,1:string}
+     */
+    public static function capture(callable $callback): array
+    {
+        $bufferLevel = ob_get_level();
+        ob_start();
+
+        try {
+            $result = $callback();
+            $content = (string) ob_get_clean();
+
+            return [$result, $content];
+        } catch (\Throwable $exception) {
+            while (ob_get_level() > $bufferLevel) {
+                ob_end_clean();
+            }
+
+            throw $exception;
+        }
+    }
+}

--- a/CorianderCore/tests/ApiControllerHandlerTest.php
+++ b/CorianderCore/tests/ApiControllerHandlerTest.php
@@ -34,6 +34,12 @@ class SampleController
     {
         return new Response(201, ['Content-Type' => 'application/json'], '{"created":true}');
     }
+
+    public function get_throws(): void
+    {
+        echo 'partial output';
+        throw new \RuntimeException('API controller failed.');
+    }
 }
 
 
@@ -150,6 +156,21 @@ class ApiControllerHandlerTest extends TestCase
 
         $this->assertNotNull($response);
         $this->assertSame(['ApiControllers\\SampleController'], $instantiated);
+    }
+
+    public function testControllerExceptionCleansOutputBuffer(): void
+    {
+        $handler = new ApiControllerHandler();
+        $bufferLevel = ob_get_level();
+
+        try {
+            $handler->dispatch('api/sample/throws', 'GET');
+            $this->fail('Expected API controller exception to be thrown.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('API controller failed.', $exception->getMessage());
+        }
+
+        $this->assertSame($bufferLevel, ob_get_level());
     }
 
     /**

--- a/CorianderCore/tests/RouterTest.php
+++ b/CorianderCore/tests/RouterTest.php
@@ -423,6 +423,43 @@ PHP;
     }
 
     /**
+     * Test that a throwing web controller action does not leak output buffers.
+     */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testWebControllerExceptionCleansOutputBuffer(): void
+    {
+        $request = new ServerRequest('GET', '/test-controller');
+
+        $controllerCode = <<<'PHP'
+<?php
+namespace Controllers;
+
+class TestController
+{
+    public function index(): void
+    {
+        echo 'partial output';
+        throw new \RuntimeException('Web controller failed.');
+    }
+}
+PHP;
+
+        $controllerFile = PROJECT_ROOT . '/src/Controllers/TestController.php';
+        file_put_contents($controllerFile, $controllerCode);
+
+        $bufferLevel = ob_get_level();
+
+        try {
+            $this->router->dispatch($request);
+            $this->fail('Expected web controller exception to be thrown.');
+        } catch (\RuntimeException $exception) {
+            $this->assertSame('Web controller failed.', $exception->getMessage());
+        }
+
+        $this->assertSame($bufferLevel, ob_get_level());
+    }
+
+    /**
      * Test that API controller responses preserve explicit status and headers.
      */
     #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]


### PR DESCRIPTION
## Summary

Harden output buffer handling around route and controller dispatch.

This adds a shared `OutputBuffer::capture()` helper under `CorianderCore\Core\Support` and uses it when dispatching:

- custom route callbacks
- web controller actions
- API controller actions
- rendered views

If user code throws after emitting output, Coriander now cleans framework-owned output buffers before rethrowing the exception.

## Tests

Added regression coverage for:

- custom route exceptions
- web controller exceptions
- API controller exceptions

Full test suite passes:

```text
OK (149 tests, 316 assertions)