### PR TITLE
Improve CLI exit codes across commands

### DIFF
--- a/CorianderCore/Tests/MigrateCommandTest.php
+++ b/CorianderCore/Tests/MigrateCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace CorianderCore\Tests;
 
 use CorianderCore\Core\Console\Commands\Migrate;
+use CorianderCore\Core\Console\CommandExitCode;
 use PHPUnit\Framework\TestCase;
 
 class MigrateCommandTest extends TestCase
@@ -43,10 +44,22 @@ class MigrateCommandTest extends TestCase
         $command = new Migrate();
 
         ob_start();
-        $command->execute(['--allow-changed']);
+        $exitCode = $command->execute(['--allow-changed']);
         $output = (string) ob_get_clean();
 
+        $this->assertSame(CommandExitCode::SUCCESS, $exitCode);
         $this->assertStringContainsString('Database is up to date.', $output);
     }
-}
 
+    public function testUnknownActionReturnsUnknownCommand(): void
+    {
+        $command = new Migrate();
+
+        ob_start();
+        $exitCode = $command->execute(['unknown']);
+        $output = (string) ob_get_clean();
+
+        $this->assertSame(CommandExitCode::UNKNOWN_COMMAND, $exitCode);
+        $this->assertStringContainsString('Unknown migrate command: migrate:unknown', $output);
+    }
+}

--- a/CorianderCore/Tests/NodeJSTest.php
+++ b/CorianderCore/Tests/NodeJSTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 namespace CorianderCore\Tests;
 
 use CorianderCore\Core\Console\Commands\NodeJS;
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\Services\Node\NpmExecutableResolver;
 use PHPUnit\Framework\TestCase;
 
@@ -33,9 +34,10 @@ class NodeJSTest extends TestCase
         $command = new NodeJS();
 
         ob_start();
-        $command->execute([]);
+        $exitCode = $command->execute([]);
         $output = (string) ob_get_clean();
 
+        $this->assertSame(CommandExitCode::INVALID_USAGE, $exitCode);
         $this->assertStringContainsString('Please provide a Node.js command to run', $output);
     }
 
@@ -44,9 +46,10 @@ class NodeJSTest extends TestCase
         $command = new NodeJS(PHP_BINARY);
 
         ob_start();
-        $command->execute(['run', 'watch-tw']);
+        $exitCode = $command->execute(['run', 'watch-tw']);
         $output = (string) ob_get_clean();
 
+        $this->assertSame(CommandExitCode::FAILURE, $exitCode);
         $this->assertStringContainsString('Starting watcher... Press Ctrl+C to stop.', $output);
         $this->assertStringContainsString('Could not open input file', $output);
         $this->assertStringContainsString('npm command failed with exit code', $output);

--- a/CorianderCore/Tests/UpdateCommandTest.php
+++ b/CorianderCore/Tests/UpdateCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CorianderCore\Tests;
 
 use CorianderCore\Core\Console\Commands\Update;
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\Services\Updater\FrameworkUpdateService;
 use CorianderCore\Core\Console\Services\Updater\PostUpdateTasksService;
 use PHPUnit\Framework\TestCase;
@@ -41,9 +42,10 @@ class UpdateCommandTest extends TestCase
         }, $postTasks);
 
         ob_start();
-        $command->execute(['--dry-run']);
+        $exitCode = $command->execute(['--dry-run']);
         $output = (string) ob_get_clean();
 
+        $this->assertSame(CommandExitCode::SUCCESS, $exitCode);
         $this->assertTrue($service->runUpdateCalled);
         $this->assertTrue($service->lastDryRunFlag);
         $this->assertFalse($postTasks->runCalled);
@@ -57,9 +59,10 @@ class UpdateCommandTest extends TestCase
         $command = new Update($service, static fn(string $message): bool => false, $postTasks);
 
         ob_start();
-        $command->execute([]);
+        $exitCode = $command->execute([]);
         $output = (string) ob_get_clean();
 
+        $this->assertSame(CommandExitCode::FAILURE, $exitCode);
         $this->assertFalse($service->runUpdateCalled);
         $this->assertFalse($postTasks->runCalled);
         $this->assertStringContainsString('Update cancelled.', $output);
@@ -74,9 +77,10 @@ class UpdateCommandTest extends TestCase
         }, $postTasks);
 
         ob_start();
-        $command->execute(['--yes']);
+        $exitCode = $command->execute(['--yes']);
         $output = (string) ob_get_clean();
 
+        $this->assertSame(CommandExitCode::SUCCESS, $exitCode);
         $this->assertTrue($service->runUpdateCalled);
         $this->assertFalse($service->lastDryRunFlag);
         $this->assertTrue($postTasks->runCalled);
@@ -105,9 +109,10 @@ class UpdateCommandTest extends TestCase
         $command = new Update($service, static fn(string $message): bool => true, $postTasks);
 
         ob_start();
-        $command->execute(['--rollback', '--yes']);
+        $exitCode = $command->execute(['--rollback', '--yes']);
         $output = (string) ob_get_clean();
 
+        $this->assertSame(CommandExitCode::SUCCESS, $exitCode);
         $this->assertTrue($service->rollbackCalled);
         $this->assertFalse($service->runUpdateCalled);
         $this->assertTrue($postTasks->runCalled);

--- a/CorianderCore/Tests/VersionCommandTest.php
+++ b/CorianderCore/Tests/VersionCommandTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace CorianderCore\Tests;
 
 use CorianderCore\Core\Console\Commands\Version;
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\Services\Updater\FrameworkVersionService;
 use PHPUnit\Framework\TestCase;
 
@@ -21,9 +22,10 @@ class VersionCommandTest extends TestCase
             $command = new Version($service);
 
             ob_start();
-            $command->execute([]);
+            $exitCode = $command->execute([]);
             $output = (string) ob_get_clean();
 
+            $this->assertSame(CommandExitCode::SUCCESS, $exitCode);
             $this->assertStringContainsString('Framework version:', $output);
             $this->assertStringContainsString('v9.9.9', $output);
         } finally {

--- a/CorianderCore/core/Console/CommandExitCode.php
+++ b/CorianderCore/core/Console/CommandExitCode.php
@@ -1,0 +1,12 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Core\Console;
+
+final class CommandExitCode
+{
+    public const SUCCESS = 0;
+    public const FAILURE = 1;
+    public const INVALID_USAGE = 2;
+    public const UNKNOWN_COMMAND = 3;
+}

--- a/CorianderCore/core/Console/CommandHandler.php
+++ b/CorianderCore/core/Console/CommandHandler.php
@@ -38,56 +38,49 @@ class CommandHandler
      * @param string $command The command name to execute
      * @param array $args The arguments passed to the command
      * @throws \Exception If the command does not exist or the command class lacks an 'execute' method.
-     * @return void
+     * @return int Process exit code.
      */
-    public function handle(string $command, array $args): void
+    public function handle(string $command, array $args): int
     {
         ConsoleOutput::hr();
-        // Check if the command contains a colon (e.g., make:view)
         $splitCommand = explode(':', $command);
 
-        // If it's a subcommand (e.g., make:view), treat it as "make" with "view" as the subcommand
         $mainCommand = $splitCommand[0];
-        $subCommand = $splitCommand[1] ?? null; // Get subcommand if present
+        $subCommand = $splitCommand[1] ?? null;
 
-        // If 'help' is requested or no command is provided, display the list of commands
         if ($mainCommand === 'help' || !$mainCommand) {
             $this->listCommands();
             ConsoleOutput::hr();
-            return;
+            return CommandExitCode::SUCCESS;
         }
 
-        // Check if the main command exists
         if (!isset($this->commands[$mainCommand])) {
             ConsoleOutput::print("&4[Error]&7 Unknown command: {$mainCommand}\n");
             $this->listCommands();
             ConsoleOutput::hr();
-            return;
+            return CommandExitCode::UNKNOWN_COMMAND;
         }
 
         $commandClass = $this->commands[$mainCommand];
 
-        // Check if the corresponding class exists for the main command
         if (!class_exists($commandClass)) {
             throw new \Exception("Command class {$commandClass} not found.");
         }
 
-        // Instantiate the main command class
         $commandInstance = new $commandClass();
 
-        // If it's a subcommand (e.g., view for make:view), pass it as the first argument
         if ($subCommand) {
             array_unshift($args, $subCommand);
         }
 
-        // Ensure the main command class has an 'execute' method
         if (!method_exists($commandInstance, 'execute')) {
             throw new \Exception("Command {$mainCommand} does not have an execute method.");
         }
 
-        // Execute the main command with the provided arguments (subcommand included)
-        $commandInstance->execute($args);
+        $result = $commandInstance->execute($args);
         ConsoleOutput::hr();
+
+        return $this->normalizeExitCode($result);
     }
 
     /**
@@ -99,13 +92,24 @@ class CommandHandler
     {
         ConsoleOutput::print("Available commands:");
 
-        // Always include 'help' as an available command
         ConsoleOutput::print("| - help");
 
-        // List all commands from the $commands array
         foreach ($this->commands as $cmd => $class) {
             ConsoleOutput::print("| - {$cmd}");
         }
+    }
+
+    private function normalizeExitCode(mixed $result): int
+    {
+        if (is_int($result)) {
+            return max(0, min(255, $result));
+        }
+
+        if (is_bool($result)) {
+            return $result ? CommandExitCode::SUCCESS : CommandExitCode::FAILURE;
+        }
+
+        return CommandExitCode::SUCCESS;
     }
 }
 

--- a/CorianderCore/core/Console/Commands/Benchmark.php
+++ b/CorianderCore/core/Console/Commands/Benchmark.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace CorianderCore\Core\Console\Commands;
 
 use CorianderCore\Core\Console\ConsoleOutput;
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\Commands\Benchmark\BenchmarkRouter;
 
 /**
@@ -53,14 +54,14 @@ class Benchmark
      * - 'php coriander benchmark:router' will benchmark the router performance.
      *
      * @param array $args The arguments passed to the benchmark command, including the subcommand and resource name.
-     * @return void
+     * @return int Process exit code.
      */
-    public function execute(array $args): void
+    public function execute(array $args): int
     {
         // Ensure the command has at least one argument (the subcommand)
         if (empty($args) || !isset($args[0])) {
             $this->listCommands();
-            return;
+            return CommandExitCode::SUCCESS;
         }
 
         // Extract the subcommand (e.g. 'router')
@@ -71,7 +72,7 @@ class Benchmark
             // Display an error message and list valid subcommands if the subcommand is invalid
             ConsoleOutput::print("&4[Error]&7 Unknown benchmark command: benchmark:{$subcommand}\n");
             $this->listCommands();
-            return;
+            return CommandExitCode::UNKNOWN_COMMAND;
         }
 
         // Extract the remaining arguments, which are specific to the resource (e.g., view or controller name)
@@ -80,13 +81,13 @@ class Benchmark
         // Delegate the execution based on the subcommand type
         switch ($subcommand) {
             case 'router':
-                $this->benchmarkRouter($resourceArgs); // Delegate to the BenchmarkRouter handler
-                break;
+                return $this->benchmarkRouter($resourceArgs); // Delegate to the BenchmarkRouter handler
 
             default:
                 // This fallback case is unlikely to be triggered due to the earlier validation,
                 // but serves as a safety net to catch any unforeseen issues.
                 ConsoleOutput::print("&4[Error]&7 Unknown benchmark command: benchmark:{$subcommand}\n");
+                return CommandExitCode::UNKNOWN_COMMAND;
         }
     }
 
@@ -98,10 +99,10 @@ class Benchmark
      * @param array $args The arguments for benchmarking the router.
      * @return void
      */
-    protected function benchmarkRouter(array $args): void
+    protected function benchmarkRouter(array $args): int
     {
         // Delegate the router benchmarking task to the BenchmarkRouter class
-        $this->benchmarkRouterInstance->execute($args);
+        return $this->benchmarkRouterInstance->execute($args);
     }
 
     /**

--- a/CorianderCore/core/Console/Commands/Benchmark/BenchmarkRouter.php
+++ b/CorianderCore/core/Console/Commands/Benchmark/BenchmarkRouter.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 namespace CorianderCore\Core\Console\Commands\Benchmark;
 
 use CorianderCore\Core\Benchmark\BenchmarkHandler;
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\ConsoleOutput;
 use CorianderCore\Core\Router\Router;
 use CorianderCore\Core\Router\NameFormatter;
@@ -23,9 +24,9 @@ class BenchmarkRouter
      * Executes the benchmark process for the router.
      *
      * @param array $args The arguments passed to the benchmark:router command (e.g., route name, duration).
-     * @return void
+     * @return int Process exit code.
      */
-    public function execute(array $args): void
+    public function execute(array $args): int
     {
         // Default route to 'home' if not specified
         $route = $args[0] ?? 'home';
@@ -39,7 +40,7 @@ class BenchmarkRouter
         // Verify if the route exists
         if (!$this->routeExists($router, $route)) {
             ConsoleOutput::print("&4[Error]&7 Route '{$route}' does not exist.");
-            return;
+            return CommandExitCode::INVALID_USAGE;
         }
 
         // Initialize BenchmarkHandler
@@ -81,6 +82,7 @@ class BenchmarkRouter
         ConsoleOutput::print("Average CPU Usage per Iteration: &7" . formatTime($results['average_cpu_usage_per_iteration']));
         ConsoleOutput::print("Total CPU Usage: &7" . formatTime($results['total_cpu_usage']));
         ConsoleOutput::print("Total CPU Usage: &7" . round($results['cpu_usage_percentage'], 3) . " %");
+        return CommandExitCode::SUCCESS;
     }
 
     /**

--- a/CorianderCore/core/Console/Commands/Cache.php
+++ b/CorianderCore/core/Console/Commands/Cache.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands;
 
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\ConsoleOutput;
 use CorianderCore\Core\Router\Services\ControllerCacheService;
 
@@ -32,32 +33,34 @@ class Cache
     /**
      * Execute the cache command.
      */
-    public function execute(array $args): void
+    public function execute(array $args): int
     {
         if (empty($args) || !isset($args[0])) {
             $this->listCommands();
-            return;
+            return CommandExitCode::SUCCESS;
         }
 
         $subcommand = strtolower($args[0]);
         if (!in_array($subcommand, $this->validSubcommands, true)) {
             ConsoleOutput::print("&4[Error]&7 Unknown cache command: cache:{$subcommand}\n");
             $this->listCommands();
-            return;
+            return CommandExitCode::UNKNOWN_COMMAND;
         }
 
         $resourceArgs = array_slice($args, 1);
         switch ($subcommand) {
             case 'controllers':
                 $this->cacheControllers($resourceArgs);
-                break;
+                return CommandExitCode::SUCCESS;
             case 'all':
                 $this->cacheAll($resourceArgs);
-                break;
+                return CommandExitCode::SUCCESS;
             case 'clear':
                 $this->clearCache($resourceArgs);
-                break;
+                return CommandExitCode::SUCCESS;
         }
+
+        return CommandExitCode::UNKNOWN_COMMAND;
     }
 
     protected function cacheControllers(array $args): void

--- a/CorianderCore/core/Console/Commands/Hello.php
+++ b/CorianderCore/core/Console/Commands/Hello.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands;
 
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\ConsoleOutput;
 
 class Hello
@@ -19,11 +20,11 @@ class Hello
      * 'hello' command is invoked through the CommandHandler. It serves as 
      * a basic example of a command that can be executed in the console.
      *
-     * @return void
+     * @return int Process exit code.
      */
-    public function execute(): void
+    public function execute(): int
     {
         ConsoleOutput::print("Hi! I'm &2Coriander&7, how can I help you?");
+        return CommandExitCode::SUCCESS;
     }
 }
-

--- a/CorianderCore/core/Console/Commands/Make.php
+++ b/CorianderCore/core/Console/Commands/Make.php
@@ -8,6 +8,7 @@ use CorianderCore\Core\Console\Commands\Make\Database\MakeDatabase;
 use CorianderCore\Core\Console\Commands\Make\Migration\MakeMigration;
 use CorianderCore\Core\Console\Commands\Make\Sitemap\MakeSitemap;
 use CorianderCore\Core\Console\Commands\Make\View\MakeView;
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\ConsoleOutput;
 
 class Make
@@ -41,98 +42,95 @@ class Make
     /**
      * @param array<int, string> $args
      */
-    public function execute(array $args): void
+    public function execute(array $args): int
     {
         if ($args === [] || !isset($args[0])) {
             $this->listCommands();
-            return;
+            return CommandExitCode::SUCCESS;
         }
 
         $subcommand = strtolower($args[0]);
         if (!in_array($subcommand, $this->validSubcommands, true)) {
             ConsoleOutput::print("&4[Error]&7 Unknown make command: make:{$subcommand}");
             $this->listCommands();
-            return;
+            return CommandExitCode::UNKNOWN_COMMAND;
         }
 
         $resourceArgs = array_slice($args, 1);
 
         switch ($subcommand) {
             case 'view':
-                $this->makeView($resourceArgs);
-                return;
+                return $this->makeView($resourceArgs);
 
             case 'controller':
-                $this->makeController($resourceArgs);
-                return;
+                return $this->makeController($resourceArgs);
 
             case 'database':
-                $this->makeDatabase($resourceArgs);
-                return;
+                return $this->makeDatabase($resourceArgs);
 
             case 'sitemap':
-                $this->makeSitemap($resourceArgs);
-                return;
+                return $this->makeSitemap($resourceArgs);
 
             case 'migration':
-                $this->makeMigration($resourceArgs);
-                return;
+                return $this->makeMigration($resourceArgs);
         }
+
+        return CommandExitCode::UNKNOWN_COMMAND;
     }
 
     /**
      * @param array<int, string> $args
      */
-    protected function makeView(array $args): void
+    protected function makeView(array $args): int
     {
         if ($args === []) {
             ConsoleOutput::print("&4[Error]&7 Please specify a view name, e.g., 'make:view agenda'.");
-            return;
+            return CommandExitCode::INVALID_USAGE;
         }
 
-        $this->makeViewInstance->execute($args);
+        return $this->makeViewInstance->execute($args);
     }
 
     /**
      * @param array<int, string> $args
      */
-    protected function makeController(array $args): void
+    protected function makeController(array $args): int
     {
         if ($args === []) {
             ConsoleOutput::print("&4[Error]&7 Please specify a controller name, e.g., 'make:controller Agenda'.");
-            return;
+            return CommandExitCode::INVALID_USAGE;
         }
 
-        $this->makeControllerInstance->execute($args);
+        return $this->makeControllerInstance->execute($args);
     }
 
     /**
      * @param array<int, string> $args
      */
-    protected function makeDatabase(array $args): void
+    protected function makeDatabase(array $args): int
     {
-        $this->makeDatabaseInstance->execute();
+        return $this->makeDatabaseInstance->execute();
     }
 
     /**
      * @param array<int, string> $args
      */
-    protected function makeSitemap(array $args): void
+    protected function makeSitemap(array $args): int
     {
-        $this->makeSitemapInstance->execute($args);
+        return $this->makeSitemapInstance->execute();
     }
 
     /**
      * @param array<int, string> $args
      */
-    protected function makeMigration(array $args): void
+    protected function makeMigration(array $args): int
     {
         if ($args === []) {
             ConsoleOutput::print("&4[Error]&7 Please specify a migration name, e.g., 'make:migration CreateUsersTable'.");
-            return;
+            return CommandExitCode::INVALID_USAGE;
         }
 
-        $this->makeMigrationInstance->execute($args);
+        return $this->makeMigrationInstance->execute($args);
     }
 
     protected function listCommands(): void

--- a/CorianderCore/core/Console/Commands/Make/Controller/MakeController.php
+++ b/CorianderCore/core/Console/Commands/Make/Controller/MakeController.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands\Make\Controller;
 
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\ConsoleOutput;
 use CorianderCore\Core\Router\NameFormatter;
 
@@ -54,11 +55,11 @@ class MakeController
      *
      * @param array $args The arguments passed to the command, where the first argument is the controller name.
      */
-    public function execute(array $args): void
+    public function execute(array $args): int
     {
         if (empty($args)) {
             ConsoleOutput::print("&4[Error]&7 Please specify a controller name.");
-            return;
+            return CommandExitCode::INVALID_USAGE;
         }
 
         $controllerNameRaw = $args[0];
@@ -78,14 +79,16 @@ class MakeController
 
         if ($this->controllerExists($controllerPath)) {
             ConsoleOutput::print("&4[Error]&7 Controller '{$controllerName}' already exists at '{$controllerPath}'.");
-            return;
+            return CommandExitCode::FAILURE;
         }
 
         try {
             $this->createFileFromTemplate($templateFile, $controllerPath, $controllerName, $kebabCaseName);
             ConsoleOutput::print("&2[Success]&7 Controller '{$controllerName}' created successfully at '{$controllerPath}'. ");
+            return CommandExitCode::SUCCESS;
         } catch (\Exception $e) {
             ConsoleOutput::print("&4[Error]&7 Failed to create controller: " . $e->getMessage());
+            return CommandExitCode::FAILURE;
         }
     }
 

--- a/CorianderCore/core/Console/Commands/Make/Database/MakeDatabase.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/MakeDatabase.php
@@ -5,6 +5,7 @@ namespace CorianderCore\Core\Console\Commands\Make\Database;
 
 use CorianderCore\Core\Console\Commands\Make\Database\MySQL\MakeMySQL;
 use CorianderCore\Core\Console\Commands\Make\Database\SQLite\MakeSQLite;
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\Services\PdoDriverService;
 use CorianderCore\Core\Console\ConsoleOutput;
 
@@ -34,7 +35,7 @@ class MakeDatabase
      * Executes the database configuration process based on user input.
      * Checks for the necessary PDO drivers before prompting the user to choose between MySQL and SQLite.
      */
-    public function execute(): void
+    public function execute(): int
     {
         // Check available PDO drivers and warn if MySQL driver is missing
         $availableDrivers = $this->pdoDriverService->getAvailableDrivers();
@@ -75,20 +76,18 @@ class MakeDatabase
                 case '0':
                 case '':
                     ConsoleOutput::print("Exiting the database creation process.");
-                    return;  // Exit the loop and terminate the script
+                    return CommandExitCode::SUCCESS;  // Exit the loop and terminate the script
                 case '1':
                     if ($mysqlAvailable) {
                         $mysqlMaker = new MakeMySQL();
-                        $mysqlMaker->execute();
-                        return;  // Exit the loop after successful MySQL execution
+                        return $mysqlMaker->execute();  // Exit the loop after successful MySQL execution
                     } else {
                         ConsoleOutput::print("&l&4[Error]&7 MySQL is not available on this system.");
                     }
                     break;
                 case '2':
                     $sqliteMaker = new MakeSQLite();
-                    $sqliteMaker->execute();
-                    return;  // Exit the loop after successful SQLite execution
+                    return $sqliteMaker->execute();  // Exit the loop after successful SQLite execution
                 default:
                     ConsoleOutput::print("&4[Error]&7 Invalid choice. Please enter &l0&r&7 to exit, &l1&r&7 for MySQL, or &l2&r&7 for SQLite.");
                     break;

--- a/CorianderCore/core/Console/Commands/Make/Database/MySQL/MakeMySQL.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/MySQL/MakeMySQL.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands\Make\Database\MySQL;
 
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\ConsoleOutput;
 use \PDO;
 use \PDOException;
@@ -39,7 +40,7 @@ class MakeMySQL
      * Executes the process of creating a MySQL configuration.
      * Prompts the user for MySQL connection details and generates a config file.
      */
-    public function execute(): void
+    public function execute(): int
     {
         // Ask the user for MySQL connection details
         ConsoleOutput::print("Enter MySQL host:\n");
@@ -71,12 +72,13 @@ class MakeMySQL
             $confirmation = strtolower(trim((string)fgets(STDIN)));
             if ($confirmation !== 'y') {
                 ConsoleOutput::print("&e[Warning]&7 Database configuration file not created.");
-                return;
+                return CommandExitCode::FAILURE;
             }
         }
 
         // Generate MySQL configuration
         $this->generateConfig($dbHost, $dbName, $dbUser, $dbPassword);
+        return CommandExitCode::SUCCESS;
     }
 
     /**

--- a/CorianderCore/core/Console/Commands/Make/Database/SQLite/MakeSQLite.php
+++ b/CorianderCore/core/Console/Commands/Make/Database/SQLite/MakeSQLite.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands\Make\Database\SQLite;
 
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\ConsoleOutput;
 
 /**
@@ -47,12 +48,17 @@ class MakeSQLite
      *
      * @param string|null $dbName Optional database name. If null, prompts the user for input.
      */
-    public function execute(?string $dbName = null): void
+    public function execute(?string $dbName = null): int
     {
         // Ask the user for the SQLite database name if not provided
         if (empty($dbName)) {
             ConsoleOutput::print("Enter SQLite database name (without extension):\n");
-            $dbName = trim(fgets(STDIN));
+            $dbName = trim((string) fgets(STDIN));
+        }
+
+        if (trim($dbName) === '') {
+            ConsoleOutput::print('&4[Error]&7 Please specify a SQLite database name.');
+            return CommandExitCode::INVALID_USAGE;
         }
 
         ConsoleOutput::hr();
@@ -63,6 +69,7 @@ class MakeSQLite
 
         ConsoleOutput::hr();
         ConsoleOutput::print("&2[Success]&r&7 Database " . $dbName . ".sqlite created in folder: " . $this->databaseFolder);
+        return CommandExitCode::SUCCESS;
     }
 
     /**

--- a/CorianderCore/core/Console/Commands/Make/Migration/MakeMigration.php
+++ b/CorianderCore/core/Console/Commands/Make/Migration/MakeMigration.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands\Make\Migration;
 
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\ConsoleOutput;
 use RuntimeException;
 
@@ -16,17 +17,17 @@ class MakeMigration
     /**
      * @param array<int, string> $args
      */
-    public function execute(array $args): void
+    public function execute(array $args): int
     {
         if (!isset($args[0]) || trim($args[0]) === '') {
             ConsoleOutput::print('&4[Error]&7 Please specify a migration name, e.g., make:migration CreateUsersTable.');
-            return;
+            return CommandExitCode::INVALID_USAGE;
         }
 
         $slug = $this->toSnakeCase((string) $args[0]);
         if ($slug === '') {
             ConsoleOutput::print('&4[Error]&7 Invalid migration name. Use letters, numbers, or underscores.');
-            return;
+            return CommandExitCode::INVALID_USAGE;
         }
 
         $timestamp = date('YmdHis');
@@ -39,12 +40,13 @@ class MakeMigration
         $fullPath = $this->migrationsDirectory . '/' . $filename;
         if (file_exists($fullPath)) {
             ConsoleOutput::print('&4[Error]&7 Migration file already exists: ' . $filename);
-            return;
+            return CommandExitCode::FAILURE;
         }
 
         file_put_contents($fullPath, $this->buildTemplate());
 
         ConsoleOutput::print('&2[Success]&7 Migration created: &8' . $this->relativePath($fullPath));
+        return CommandExitCode::SUCCESS;
     }
 
     private function buildTemplate(): string

--- a/CorianderCore/core/Console/Commands/Make/Sitemap/MakeSitemap.php
+++ b/CorianderCore/core/Console/Commands/Make/Sitemap/MakeSitemap.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands\Make\Sitemap;
 
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\ConsoleOutput;
 
 /**
@@ -45,7 +46,7 @@ class MakeSitemap
      * - If a sitemap already exists, an error message is displayed.
      * - If the sitemap is successfully created, a success message is displayed.
      */
-    public function execute(): void
+    public function execute(): int
     {
         try {
             // Guard clause to prevent overwriting an existing sitemap.
@@ -58,9 +59,11 @@ class MakeSitemap
 
             // Success message after sitemap creation.
             ConsoleOutput::print("&2[Success]&r&7 Sitemap created successfully at '{$this->sitemapFilePath}'.");
+            return CommandExitCode::SUCCESS;
         } catch (\Exception $e) {
             // Handle any exceptions during the creation process.
             ConsoleOutput::print("&4[Error]&7 " . $e->getMessage());
+            return CommandExitCode::FAILURE;
         }
     }
 

--- a/CorianderCore/core/Console/Commands/Make/View/MakeView.php
+++ b/CorianderCore/core/Console/Commands/Make/View/MakeView.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands\Make\View;
 
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\ConsoleOutput;
 use CorianderCore\Core\Utils\DirectoryHandler;
 
@@ -50,7 +51,7 @@ class MakeView
      *
      * @param array $args The arguments passed to the command, where the first argument is the view name.
      */
-    public function execute(array $args): void
+    public function execute(array $args): int
     {
         try {
             // Ensure a view name is provided.
@@ -76,10 +77,14 @@ class MakeView
 
             // Output success message.
             ConsoleOutput::print("&2[Success]&r&7 View '{$viewName}' created successfully at '{$fullViewPath}'.");
+            return CommandExitCode::SUCCESS;
 
         } catch (\Exception $e) {
             // Handle any exceptions during the creation process.
             ConsoleOutput::print("&4[Error]&7 " . $e->getMessage());
+            return str_contains($e->getMessage(), 'Please specify')
+                ? CommandExitCode::INVALID_USAGE
+                : CommandExitCode::FAILURE;
         }
     }
 

--- a/CorianderCore/core/Console/Commands/Migrate.php
+++ b/CorianderCore/core/Console/Commands/Migrate.php
@@ -6,6 +6,8 @@ namespace CorianderCore\Core\Console\Commands;
 use CorianderCore\Core\Console\Commands\Migrate\MigrateEnvironmentPolicy;
 use CorianderCore\Core\Console\Commands\Migrate\MigrateOptions;
 use CorianderCore\Core\Console\Commands\Migrate\MigrateOutputPresenter;
+use CorianderCore\Core\Console\CommandExitCode;
+use CorianderCore\Core\Console\ConsoleOutput;
 use CorianderCore\Core\Database\DatabaseHandler;
 use CorianderCore\Core\Database\Migrations\MigrationManager;
 use RuntimeException;
@@ -23,8 +25,13 @@ class Migrate
     /**
      * @param array<int, string> $args
      */
-    public function execute(array $args = []): void
+    public function execute(array $args = []): int
     {
+        if (isset($args[0]) && !str_starts_with($args[0], '--') && !in_array(strtolower($args[0]), ['rollback', 'status', 'up'], true)) {
+            ConsoleOutput::print("&4[Error]&7 Unknown migrate command: migrate:{$args[0]}");
+            return CommandExitCode::UNKNOWN_COMMAND;
+        }
+
         $options = MigrateOptions::fromArgs($args);
         $this->policy->assertAllowed($options);
 
@@ -33,14 +40,14 @@ class Migrate
         switch ($options->action) {
             case 'status':
                 $this->presenter->printStatus($manager->status($options->allowChanged));
-                return;
+                return CommandExitCode::SUCCESS;
 
             case 'rollback':
                 $this->presenter->printRollbackResult(
                     $manager->rollback($options->step, $options->dryRun),
                     $options->dryRun
                 );
-                return;
+                return CommandExitCode::SUCCESS;
 
             case 'up':
             default:
@@ -48,7 +55,7 @@ class Migrate
                     $manager->migrate($options->dryRun, $options->allowChanged),
                     $options->dryRun
                 );
-                return;
+                return CommandExitCode::SUCCESS;
         }
     }
 

--- a/CorianderCore/core/Console/Commands/NodeJS.php
+++ b/CorianderCore/core/Console/Commands/NodeJS.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace CorianderCore\Core\Console\Commands;
 
 use CorianderCore\Core\Console\ConsoleOutput;
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\Services\Node\NpmExecutableResolver;
 
 class NodeJS
@@ -24,19 +25,19 @@ class NodeJS
      * Executes the provided Node.js (npm) command.
      *
      * @param array<int, string> $args The arguments passed to the 'nodejs' command (e.g., 'install', 'run build').
-     * @return void
+     * @return int Process exit code.
      */
-    public function execute(array $args): void
+    public function execute(array $args): int
     {
         if (empty($args)) {
             ConsoleOutput::print("&4[Error]&7 Please provide a Node.js command to run. (e.g, php coriander nodejs run watch-tw)");
-            return;
+            return CommandExitCode::INVALID_USAGE;
         }
 
         $nodeDir = PROJECT_ROOT . '/nodejs';
         if (!is_dir($nodeDir)) {
             ConsoleOutput::print('&4[Error]&7 Node.js directory not found: ' . $nodeDir);
-            return;
+            return CommandExitCode::FAILURE;
         }
 
         if ($this->isWatchCommand($args)) {
@@ -55,7 +56,7 @@ class NodeJS
         $process = proc_open($command, $descriptors, $pipes, $nodeDir);
         if (!is_resource($process)) {
             ConsoleOutput::print('&4[Error]&7 Could not start the npm process.');
-            return;
+            return CommandExitCode::FAILURE;
         }
 
         fclose($pipes[0]);
@@ -71,7 +72,10 @@ class NodeJS
         if ($exitCode !== 0) {
             ConsoleOutput::print('&4[Error]&7 npm command failed with exit code ' . (string) $exitCode . '.');
             ConsoleOutput::print('&8|&7 Resolved npm executable: ' . $npmExecutable);
+            return is_int($exitCode) ? max(CommandExitCode::FAILURE, min(255, $exitCode)) : CommandExitCode::FAILURE;
         }
+
+        return CommandExitCode::SUCCESS;
     }
 
     /**

--- a/CorianderCore/core/Console/Commands/Update.php
+++ b/CorianderCore/core/Console/Commands/Update.php
@@ -5,6 +5,7 @@ namespace CorianderCore\Core\Console\Commands;
 
 use CorianderCore\Core\Console\Commands\Update\UpdateOptions;
 use CorianderCore\Core\Console\Commands\Update\UpdateOutputPresenter;
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\Services\Updater\FrameworkUpdateService;
 use CorianderCore\Core\Console\Services\Updater\PostUpdateTasksService;
 use CorianderCore\Core\Console\Services\Updater\UpdaterAccessGuard;
@@ -33,20 +34,19 @@ class Update
     /**
      * @param array<int, string> $args
      */
-    public function execute(array $args = []): void
+    public function execute(array $args = []): int
     {
         $sanitizedArgs = $this->accessGuard->assertCanRun($args);
         $options = UpdateOptions::fromArgs($sanitizedArgs);
 
         if ($options->rollback) {
-            $this->executeRollback($options);
-            return;
+            return $this->executeRollback($options);
         }
 
-        $this->executeUpdate($options);
+        return $this->executeUpdate($options);
     }
 
-    private function executeRollback(UpdateOptions $options): void
+    private function executeRollback(UpdateOptions $options): int
     {
         if ($options->dryRun) {
             $this->presenter->printRollbackDryRunWarning();
@@ -54,7 +54,7 @@ class Update
 
         if (!$options->assumeYes && !$this->confirm('Rollback latest framework backup now? [y/N]: ')) {
             $this->presenter->printRollbackCancelled();
-            return;
+            return CommandExitCode::FAILURE;
         }
 
         $result = $this->updateService->rollbackLatestBackup($options->backupDirectory);
@@ -68,9 +68,10 @@ class Update
         }
 
         $this->presenter->printRollbackSuccess();
+        return $this->postTasksSucceeded($postTaskResults) ? CommandExitCode::SUCCESS : CommandExitCode::FAILURE;
     }
 
-    private function executeUpdate(UpdateOptions $options): void
+    private function executeUpdate(UpdateOptions $options): int
     {
         $localVersion = $this->updateService->getLocalVersion();
         $latestRelease = $this->updateService->fetchLatestRelease();
@@ -81,14 +82,14 @@ class Update
 
         if (!$this->updateService->isUpdateAvailable($localVersion, $latestVersion)) {
             $this->presenter->printAlreadyUpToDate();
-            return;
+            return CommandExitCode::SUCCESS;
         }
 
         if ($options->dryRun) {
             $this->presenter->printDryRunEnabled();
         } elseif (!$options->assumeYes && !$this->confirm('A new version is available. Update now? [y/N]: ')) {
             $this->presenter->printUpdateCancelled();
-            return;
+            return CommandExitCode::FAILURE;
         }
 
         $result = $this->updateService->runUpdate(
@@ -104,7 +105,7 @@ class Update
 
         if ($options->dryRun) {
             $this->presenter->printDryRunNoChanges();
-            return;
+            return CommandExitCode::SUCCESS;
         }
 
         $this->presenter->printAppliedSummary($result, $options->force);
@@ -117,6 +118,16 @@ class Update
         }
 
         $this->presenter->printUpdateSuccess();
+        return $this->postTasksSucceeded($postTaskResults) ? CommandExitCode::SUCCESS : CommandExitCode::FAILURE;
+    }
+
+    /**
+     * @param array{composer_dump_autoload: array{success: bool, exit_code: int, output: string}, cache_clear: array{success: bool, exit_code: int, output: string}|null} $postTaskResults
+     */
+    private function postTasksSucceeded(array $postTaskResults): bool
+    {
+        return $postTaskResults['composer_dump_autoload']['success']
+            && ($postTaskResults['cache_clear'] === null || $postTaskResults['cache_clear']['success']);
     }
 
     private function confirm(string $message): bool

--- a/CorianderCore/core/Console/Commands/Version.php
+++ b/CorianderCore/core/Console/Commands/Version.php
@@ -3,6 +3,7 @@ declare(strict_types=1);
 
 namespace CorianderCore\Core\Console\Commands;
 
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\ConsoleOutput;
 use CorianderCore\Core\Console\Services\Updater\FrameworkVersionService;
 
@@ -18,9 +19,10 @@ class Version
     /**
      * @param array<int, string> $args
      */
-    public function execute(array $args = []): void
+    public function execute(array $args = []): int
     {
         $version = $this->versionService->getLocalVersion();
         ConsoleOutput::print('&lFramework version:&r &2' . $version);
+        return CommandExitCode::SUCCESS;
     }
 }

--- a/CorianderCore/tests/CommandHandlerTest.php
+++ b/CorianderCore/tests/CommandHandlerTest.php
@@ -4,6 +4,7 @@ namespace CorianderCore\Tests;
 
 use PHPUnit\Framework\TestCase;
 use CorianderCore\Core\Console\CommandHandler;
+use CorianderCore\Core\Console\CommandExitCode;
 
 class CommandHandlerTest extends TestCase
 {
@@ -33,9 +34,10 @@ class CommandHandlerTest extends TestCase
     {
         // Start output buffering to capture the output of the 'hello' command
         ob_start();
-        $this->commandHandler->handle('hello', []);
+        $exitCode = $this->commandHandler->handle('hello', []);
         $output = ob_get_clean();
 
+        $this->assertSame(CommandExitCode::SUCCESS, $exitCode);
         // Assert that the expected output message contains specific greeting strings
         $this->assertStringContainsString("Hi! I'm", $output);
         $this->assertStringContainsString("Coriander", $output);
@@ -51,9 +53,10 @@ class CommandHandlerTest extends TestCase
     {
         // Start output buffering to capture the output of the 'help' command
         ob_start();
-        $this->commandHandler->handle('help', []);
+        $exitCode = $this->commandHandler->handle('help', []);
         $output = ob_get_clean();
 
+        $this->assertSame(CommandExitCode::SUCCESS, $exitCode);
         // Assert that the output contains the expected command list
         $this->assertStringContainsString('Available commands:', $output);
         $this->assertStringContainsString('hello', $output);
@@ -69,12 +72,35 @@ class CommandHandlerTest extends TestCase
     {
         // Start output buffering to capture the output of an invalid command
         ob_start();
-        $this->commandHandler->handle('invalidCommand', []);
+        $exitCode = $this->commandHandler->handle('invalidCommand', []);
         $output = ob_get_clean();
 
+        $this->assertSame(CommandExitCode::UNKNOWN_COMMAND, $exitCode);
         // Assert that the output contains the expected error message and command list
         $this->assertStringContainsString('Unknown command: invalidCommand', $output);
         $this->assertStringContainsString('Available commands:', $output);
+    }
+
+    public function testCommandReturnCodeIsPropagated(): void
+    {
+        $mockCommandClass = get_class(new class {
+            public function execute(array $args): int
+            {
+                return 7;
+            }
+        });
+
+        $commandsProperty = (new \ReflectionClass(CommandHandler::class))->getProperty('commands');
+        $commandsProperty->setAccessible(true);
+        $commands = $commandsProperty->getValue($this->commandHandler);
+        $commands['returnsCode'] = $mockCommandClass;
+        $commandsProperty->setValue($this->commandHandler, $commands);
+
+        ob_start();
+        $exitCode = $this->commandHandler->handle('returnsCode', []);
+        ob_end_clean();
+
+        $this->assertSame(7, $exitCode);
     }
 
     /**

--- a/CorianderCore/tests/Make/MakeSQLiteTest.php
+++ b/CorianderCore/tests/Make/MakeSQLiteTest.php
@@ -4,6 +4,7 @@ namespace CorianderCore\Tests\Make;
 
 use PHPUnit\Framework\TestCase;
 use CorianderCore\Core\Console\Commands\Make\Database\SQLite\MakeSQLite;
+use CorianderCore\Core\Console\CommandExitCode;
 use CorianderCore\Core\Console\ConsoleOutput;
 use CorianderCore\Core\Utils\DirectoryHandler;
 
@@ -81,9 +82,10 @@ class MakeSQLiteTest extends TestCase
     public function testExecuteSqlite()
     {
         // Execute the MakeSQLite process
-        $this->makeSQLite->execute('test');
+        $exitCode = $this->makeSQLite->execute('test');
 
         // Expect the output to indicate success
+        $this->assertSame(CommandExitCode::SUCCESS, $exitCode);
         $this->expectOutputRegex("/\[Success\].*Database test.sqlite created in folder/");
         // Check if the SQLite files and config file were created
         $this->assertFileExists(self::$testPath . '/database/clean_test.sqlite');

--- a/CorianderCore/tests/MakeTest.php
+++ b/CorianderCore/tests/MakeTest.php
@@ -5,6 +5,7 @@ namespace CorianderCore\Tests;
 use PHPUnit\Framework\TestCase;
 use CorianderCore\Core\Console\Commands\Make;
 use CorianderCore\Core\Console\Commands\Make\View\MakeView;
+use CorianderCore\Core\Console\CommandExitCode;
 
 class MakeTest extends TestCase
 {
@@ -46,7 +47,7 @@ class MakeTest extends TestCase
         $this->expectOutputRegex("/Unknown make command: make:invalid/");
 
         // Run the make command with an invalid subcommand 'invalid'
-        $this->make->execute(['invalid']);
+        $this->assertSame(CommandExitCode::UNKNOWN_COMMAND, $this->make->execute(['invalid']));
     }
 
     /**
@@ -59,7 +60,7 @@ class MakeTest extends TestCase
         $this->expectOutputRegex("/Available make commands:/");
 
         // Run the make command with no arguments
-        $this->make->execute([]);
+        $this->assertSame(CommandExitCode::SUCCESS, $this->make->execute([]));
     }
 
     /**
@@ -72,6 +73,6 @@ class MakeTest extends TestCase
         $this->expectOutputRegex("/Please specify a view name, e.g., 'make:view agenda'/");
 
         // Run the 'make:view' command without providing a view name
-        $this->make->execute(['view']);
+        $this->assertSame(CommandExitCode::INVALID_USAGE, $this->make->execute(['view']));
     }
 }

--- a/coriander
+++ b/coriander
@@ -45,8 +45,8 @@ $args = array_slice($argv, 2);
 try {
     // Initialize and execute the command handler
     $handler = new CommandHandler();
-    $handler->handle($command, $args);
-} catch (Exception $e) {
+    exit($handler->handle($command, $args));
+} catch (Throwable $e) {
     // Handle any errors by outputting the message
     ConsoleOutput::hr();
     ConsoleOutput::print("&4[Error]&7 Failed to execute command: &8" . $command . "&7.");

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -127,7 +127,11 @@ Flags:
 ## Error Handling
 
 - Commands print diagnostic messages prefixed with `[Error]` or `[Warning]` when something goes wrong.
-- Most commands exit silently on success and non-zero on failure, allowing usage in scripts.
+- Commands return `0` on success and non-zero on command errors, allowing usage in scripts and CI.
+- Execution failures return `1`.
+- Invalid usage or bad arguments return `2`.
+- Unknown commands or subcommands return `3`.
+- Commands that wrap external processes, such as `nodejs`, propagate the external process exit code when possible.
 
 ## Best Practices
 


### PR DESCRIPTION
## Summary

Improves CLI exit-code behavior across Coriander commands.

Adds a shared `CommandExitCode` contract:

- `0` success
- `1` execution failure
- `2` invalid usage or bad arguments
- `3` unknown command or subcommand

Also updates command execution so all command entrypoints return meaningful process exit codes.

## Tests

- Added/updated command exit-code tests.
- Verified real CLI process exit codes manually.
- Full test suite passes:

```text
OK (151 tests, 334 assertions)