### PR TITLE
Align .env database configuration behavior

### DIFF
--- a/.env-example
+++ b/.env-example
@@ -10,6 +10,7 @@ DB_TYPE=sqlite
 DB_NAME=database/database.sqlite
 DB_HOST=127.0.0.1
 DB_PORT=3306
+DB_CHARSET=utf8mb4
 DB_USER=root
 DB_PASSWORD=
 

--- a/CorianderCore/Tests/ConfigEnvironmentTest.php
+++ b/CorianderCore/Tests/ConfigEnvironmentTest.php
@@ -1,0 +1,64 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Tests;
+
+use PHPUnit\Framework\TestCase;
+
+class ConfigEnvironmentTest extends TestCase
+{
+    public function testDatabaseConstantsCanBeLoadedFromEnvironment(): void
+    {
+        $output = $this->runPhpCode(<<<'PHP'
+putenv('DB_TYPE=mysql');
+putenv('DB_HOST=127.0.0.1');
+putenv('DB_PORT=3307');
+putenv('DB_CHARSET=utf8mb4');
+putenv('DB_NAME=app');
+putenv('DB_USER=root');
+putenv('DB_PASSWORD=secret');
+require 'config/config.php';
+echo DB_TYPE . '|' . DB_HOST . '|' . DB_PORT . '|' . DB_CHARSET . '|' . DB_NAME . '|' . DB_USER . '|' . DB_PASSWORD;
+PHP);
+
+        $this->assertSame('mysql|127.0.0.1|3307|utf8mb4|app|root|secret', $output);
+    }
+
+    public function testPredefinedDatabaseConstantsWinOverEnvironment(): void
+    {
+        $output = $this->runPhpCode(<<<'PHP'
+define('DB_TYPE', 'sqlite');
+putenv('DB_TYPE=mysql');
+require 'config/config.php';
+echo DB_TYPE;
+PHP);
+
+        $this->assertSame('sqlite', $output);
+    }
+
+    private function runPhpCode(string $code): string
+    {
+        $process = proc_open(
+            [PHP_BINARY, '-r', $code],
+            [
+                1 => ['pipe', 'w'],
+                2 => ['pipe', 'w'],
+            ],
+            $pipes,
+            PROJECT_ROOT
+        );
+
+        $this->assertIsResource($process);
+
+        $stdout = stream_get_contents($pipes[1]);
+        $stderr = stream_get_contents($pipes[2]);
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $exitCode = proc_close($process);
+
+        $this->assertSame(0, $exitCode, is_string($stderr) ? $stderr : '');
+
+        return trim(is_string($stdout) ? $stdout : '');
+    }
+}

--- a/CorianderCore/Tests/bootstrap.php
+++ b/CorianderCore/Tests/bootstrap.php
@@ -47,6 +47,14 @@ if (!defined('PROJECT_ROOT')) {
 $testsRoot = PROJECT_ROOT . '/CorianderCore/Tests';
 corianderCleanupTestTempArtifacts($testsRoot);
 
+$testDbPath = $testsRoot . '/_tmp_test.sqlite';
+$testDbDir = dirname($testDbPath);
+if (!is_dir($testDbDir)) {
+    mkdir($testDbDir, 0777, true);
+}
+putenv('DB_TYPE=sqlite');
+putenv('DB_NAME=' . $testDbPath);
+
 $config = PROJECT_ROOT . '/config/config.php';
 if (file_exists($config)) {
     require_once $config;
@@ -57,11 +65,6 @@ if (!defined('DB_TYPE')) {
 }
 
 if (!defined('DB_NAME')) {
-    $testDbPath = $testsRoot . '/_tmp_test.sqlite';
-    $testDbDir = dirname($testDbPath);
-    if (!is_dir($testDbDir)) {
-        mkdir($testDbDir, 0777, true);
-    }
     define('DB_NAME', $testDbPath);
 }
 

--- a/config/config.php
+++ b/config/config.php
@@ -45,6 +45,33 @@ if (!defined('API_TIMEOUT_SECONDS')) {
     define('API_TIMEOUT_SECONDS', (int) (getenv('API_TIMEOUT_SECONDS') ?: 15));
 }
 
+$databaseConfigFile = PROJECT_ROOT . '/config/database.php';
+if (file_exists($databaseConfigFile)) {
+    include_once $databaseConfigFile;
+}
+
+if (!defined('DB_TYPE') && getenv('DB_TYPE') !== false) {
+    define('DB_TYPE', getenv('DB_TYPE'));
+}
+if (!defined('DB_HOST') && getenv('DB_HOST') !== false) {
+    define('DB_HOST', getenv('DB_HOST'));
+}
+if (!defined('DB_PORT') && getenv('DB_PORT') !== false) {
+    define('DB_PORT', (int) getenv('DB_PORT'));
+}
+if (!defined('DB_CHARSET') && getenv('DB_CHARSET') !== false) {
+    define('DB_CHARSET', getenv('DB_CHARSET'));
+}
+if (!defined('DB_NAME') && getenv('DB_NAME') !== false) {
+    define('DB_NAME', getenv('DB_NAME'));
+}
+if (!defined('DB_USER') && getenv('DB_USER') !== false) {
+    define('DB_USER', getenv('DB_USER'));
+}
+if (!defined('DB_PASSWORD') && getenv('DB_PASSWORD') !== false) {
+    define('DB_PASSWORD', getenv('DB_PASSWORD'));
+}
+
 // Updater command hardening defaults
 if (!defined('CORIANDER_UPDATER_ENABLED')) {
     define('CORIANDER_UPDATER_ENABLED', getenv('CORIANDER_UPDATER_ENABLED') !== false ? getenv('CORIANDER_UPDATER_ENABLED') : '1');
@@ -54,13 +81,5 @@ if (!defined('CORIANDER_UPDATER_ALLOW_PRODUCTION')) {
 }
 if (!defined('CORIANDER_UPDATER_MAX_ATTEMPTS_PER_HOUR')) {
     define('CORIANDER_UPDATER_MAX_ATTEMPTS_PER_HOUR', (int) (getenv('CORIANDER_UPDATER_MAX_ATTEMPTS_PER_HOUR') ?: 5));
-}
-
-// Check if the database.php file exists in the config folder
-$databaseConfigFile = PROJECT_ROOT . '/config/database.php';
-
-if (file_exists($databaseConfigFile)) {
-    // Include the database configuration file
-    include_once $databaseConfigFile;
 }
 

--- a/docs/database.md
+++ b/docs/database.md
@@ -14,7 +14,21 @@ The command prompts for MySQL or SQLite and writes the appropriate settings to `
 
 ## Configuration
 
-Create `config/database.php` with the required constants:
+Database settings can come from `.env` or `config/database.php`.
+
+For local projects, `.env` is usually enough:
+
+```env
+DB_TYPE=mysql
+DB_HOST=127.0.0.1
+DB_PORT=3306
+DB_CHARSET=utf8mb4
+DB_NAME=app
+DB_USER=user
+DB_PASSWORD=secret
+```
+
+For projects that need PHP-level configuration, create `config/database.php` with the required constants:
 
 ```php
 <?php
@@ -29,7 +43,7 @@ define('DB_USER', 'user');
 define('DB_PASSWORD', 'secret');
 ```
 
-The file is automatically loaded from `config/config.php` when present. Avoid committing credentials to version control.
+The file is automatically loaded from `config/config.php` when present. Constants already defined in `config/database.php` take precedence over `.env` values. Avoid committing credentials to version control.
 
 ## Migrations
 


### PR DESCRIPTION
## Summary
- Load database constants from environment variables when `config/database.php` does not define them.
- Keep existing `config/database.php` constants as the higher-priority source.
- Add `DB_CHARSET` to `.env-example` so the example matches MySQL configuration.
- Document `.env` database configuration and precedence.
- Add isolated config tests for environment-backed DB constants.

## Tests
- `vendor\bin\phpunit --testdox`
- Result: `OK (160 tests, 356 assertions)`