### PR TITLE
Centralize public asset URL generation

### DIFF
--- a/CorianderCore/Tests/PublicUrlTest.php
+++ b/CorianderCore/Tests/PublicUrlTest.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Tests;
+
+use CorianderCore\Core\Support\PublicUrl;
+use PHPUnit\Framework\TestCase;
+
+class PublicUrlTest extends TestCase
+{
+    private mixed $previousScriptName = null;
+
+    protected function setUp(): void
+    {
+        $this->previousScriptName = $_SERVER['SCRIPT_NAME'] ?? null;
+        putenv('PUBLIC_URL_PREFIX');
+        unset($_ENV['PUBLIC_URL_PREFIX'], $_SERVER['PUBLIC_URL_PREFIX'], $_SERVER['SCRIPT_NAME']);
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('PUBLIC_URL_PREFIX');
+        unset($_ENV['PUBLIC_URL_PREFIX'], $_SERVER['PUBLIC_URL_PREFIX']);
+
+        if ($this->previousScriptName === null) {
+            unset($_SERVER['SCRIPT_NAME']);
+        } else {
+            $_SERVER['SCRIPT_NAME'] = $this->previousScriptName;
+        }
+    }
+
+    public function testAssetUsesConfiguredPublicUrlPrefix(): void
+    {
+        putenv('PUBLIC_URL_PREFIX=/public');
+
+        $this->assertSame('/public/assets/css/output.css', PublicUrl::asset('assets/css/output.css'));
+    }
+
+    public function testAssetRemovesPublicSegmentWhenPublicIsDocumentRoot(): void
+    {
+        $this->assertSame('/assets/css/output.css', PublicUrl::asset('assets/css/output.css'));
+    }
+
+    public function testAssetDetectsProjectRootServedThroughPublicIndex(): void
+    {
+        $_SERVER['SCRIPT_NAME'] = '/public/index.php';
+
+        $this->assertSame('/public/assets/css/output.css', PublicUrl::asset('assets/css/output.css'));
+    }
+
+    public function testVersionedAssetAddsFileMtimeWhenFileExists(): void
+    {
+        $url = PublicUrl::versionedAsset('assets/css/output.css');
+
+        $this->assertMatchesRegularExpression('#^/assets/css/output\.css\?\d+$#', $url);
+    }
+}

--- a/CorianderCore/core/Image/ImageHandler.php
+++ b/CorianderCore/core/Image/ImageHandler.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
 namespace CorianderCore\Core\Image;
 
 use CorianderCore\Core\Logging\StaticLoggerTrait;
+use CorianderCore\Core\Support\PublicUrl;
 
 /**
  * Handles image conversion and rendering for PNG, JPG, and JPEG files.
@@ -245,36 +246,7 @@ class ImageHandler
 
     private static function toPublicUrl(string $path): string
     {
-        if (!str_starts_with($path, '/public/')) {
-            return $path;
-        }
-
-        return self::publicUrlPrefix() . substr($path, 7);
-    }
-
-    private static function publicUrlPrefix(): string
-    {
-        if (defined('PUBLIC_URL_PREFIX')) {
-            return self::normalizeUrlPrefix((string) PUBLIC_URL_PREFIX);
-        }
-
-        $configuredPrefix = getenv('PUBLIC_URL_PREFIX');
-        if (is_string($configuredPrefix)) {
-            return self::normalizeUrlPrefix($configuredPrefix);
-        }
-
-        $scriptName = str_replace('\\', '/', (string) ($_SERVER['SCRIPT_NAME'] ?? ''));
-        return str_contains($scriptName, '/public/index.php') ? '/public' : '';
-    }
-
-    private static function normalizeUrlPrefix(string $prefix): string
-    {
-        $prefix = trim($prefix);
-        if ($prefix === '' || $prefix === '/') {
-            return '';
-        }
-
-        return '/' . trim($prefix, '/');
+        return PublicUrl::toPublicUrl($path);
     }
 
     private static function escapeHtmlAttribute(string $value): string

--- a/CorianderCore/core/Support/PublicUrl.php
+++ b/CorianderCore/core/Support/PublicUrl.php
@@ -1,0 +1,66 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Core\Support;
+
+final class PublicUrl
+{
+    public static function asset(string $path): string
+    {
+        return self::toPublicUrl('/public/' . ltrim(str_replace('\\', '/', $path), '/'));
+    }
+
+    public static function versionedAsset(string $path): string
+    {
+        $url = self::asset($path);
+        $filePath = self::publicFilePath($path);
+
+        if (!is_file($filePath)) {
+            return $url;
+        }
+
+        $mtime = filemtime($filePath);
+        return $mtime === false ? $url : $url . '?' . $mtime;
+    }
+
+    public static function toPublicUrl(string $path): string
+    {
+        $path = '/' . ltrim(str_replace('\\', '/', trim($path)), '/');
+        if (!str_starts_with($path, '/public/')) {
+            return $path;
+        }
+
+        return self::publicUrlPrefix() . substr($path, 7);
+    }
+
+    private static function publicUrlPrefix(): string
+    {
+        if (defined('PUBLIC_URL_PREFIX')) {
+            return self::normalizePrefix((string) PUBLIC_URL_PREFIX);
+        }
+
+        $configuredPrefix = getenv('PUBLIC_URL_PREFIX');
+        if (is_string($configuredPrefix)) {
+            return self::normalizePrefix($configuredPrefix);
+        }
+
+        $scriptName = str_replace('\\', '/', (string) ($_SERVER['SCRIPT_NAME'] ?? ''));
+        return str_contains($scriptName, '/public/index.php') ? '/public' : '';
+    }
+
+    private static function normalizePrefix(string $prefix): string
+    {
+        $prefix = trim($prefix);
+        if ($prefix === '' || $prefix === '/') {
+            return '';
+        }
+
+        return '/' . trim($prefix, '/');
+    }
+
+    private static function publicFilePath(string $path): string
+    {
+        $projectRoot = defined('PROJECT_ROOT') ? (string) PROJECT_ROOT : dirname(__DIR__, 3);
+        return rtrim(str_replace('\\', '/', $projectRoot), '/') . '/public/' . ltrim(str_replace('\\', '/', $path), '/');
+    }
+}

--- a/public/public_views/footer.php
+++ b/public/public_views/footer.php
@@ -11,7 +11,7 @@
 $requestedView = isset($__corianderRequestedView) ? $__corianderRequestedView : 'home';
 if (file_exists(PROJECT_ROOT . '/public/public_views/' . $requestedView . '/index.php') && file_exists(PROJECT_ROOT . '/public/assets/js/' . $requestedView . '/index.js')) {
 ?>
-    <script type="module" src="/public/assets/js/<?= $requestedView ?>/index.js?<?php echo filemtime(PROJECT_ROOT . '/public/assets/js/' . $requestedView . '/index.js'); ?>" defer></script>
+    <script type="module" src="<?= \CorianderCore\Core\Support\PublicUrl::versionedAsset('assets/js/' . $requestedView . '/index.js') ?>" defer></script>
 <?php
 }
 ?>

--- a/public/public_views/header.php
+++ b/public/public_views/header.php
@@ -22,7 +22,7 @@ if (file_exists($metaDataPath)) {
     }
     ?>
 
-    <link rel="stylesheet" href="/public/assets/css/output.css?<?php echo filemtime(PROJECT_ROOT . '/public/assets/css/output.css'); ?>">
+    <link rel="stylesheet" href="<?= \CorianderCore\Core\Support\PublicUrl::versionedAsset('assets/css/output.css') ?>">
 </head>
 
 <body class="bg-white dark:bg-black w-full absolute min-h-full scrollbar text-black dark:text-white">


### PR DESCRIPTION
## Summary
- Add a lightweight `PublicUrl` helper for public asset URL generation.
- Reuse the helper in `ImageHandler`, the default header, and the default footer.
- Preserve `PUBLIC_URL_PREFIX` and `/public/index.php` auto-detection behavior.
- Add tests for configured prefixes, public document-root behavior, auto-detection, and versioned assets.

## Tests
- `vendor\bin\phpunit --testdox`
- Result: `OK (162 tests, 354 assertions)`