### PR TITLE
Split public index bootstrap responsibilities

### DIFF
--- a/CorianderCore/Tests/RequestFactoryTest.php
+++ b/CorianderCore/Tests/RequestFactoryTest.php
@@ -1,0 +1,59 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Tests;
+
+use CorianderCore\Core\Http\RequestFactory;
+use PHPUnit\Framework\TestCase;
+
+class RequestFactoryTest extends TestCase
+{
+    public function testCreatesRequestFromServerValues(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            [
+                'REQUEST_METHOD' => 'GET',
+                'REQUEST_URI' => '/users',
+                'SERVER_PROTOCOL' => 'HTTP/2',
+            ],
+            [],
+            ['Accept' => 'application/json'],
+            ''
+        );
+
+        $this->assertSame('GET', $request->getMethod());
+        $this->assertSame('/users', $request->getUri()->getPath());
+        $this->assertSame('2', $request->getProtocolVersion());
+        $this->assertSame('application/json', $request->getHeaderLine('Accept'));
+    }
+
+    public function testParsesJsonBodyForMutatingRequests(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            [
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_URI' => '/api/users',
+            ],
+            [],
+            ['Content-Type' => 'application/json'],
+            '{"name":"Lohan"}'
+        );
+
+        $this->assertSame(['name' => 'Lohan'], $request->getParsedBody());
+    }
+
+    public function testUsesPostParamsForFormRequests(): void
+    {
+        $request = RequestFactory::fromGlobals(
+            [
+                'REQUEST_METHOD' => 'POST',
+                'REQUEST_URI' => '/users',
+            ],
+            ['name' => 'Lohan'],
+            ['Content-Type' => 'application/x-www-form-urlencoded'],
+            'name=Lohan'
+        );
+
+        $this->assertSame(['name' => 'Lohan'], $request->getParsedBody());
+    }
+}

--- a/CorianderCore/Tests/TrustedProxyTest.php
+++ b/CorianderCore/Tests/TrustedProxyTest.php
@@ -1,0 +1,31 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Tests;
+
+use CorianderCore\Core\Http\TrustedProxy;
+use PHPUnit\Framework\TestCase;
+
+class TrustedProxyTest extends TestCase
+{
+    public function testDetectsDirectHttpsRequest(): void
+    {
+        $this->assertTrue(TrustedProxy::isSecureRequest(['HTTPS' => 'on']));
+    }
+
+    public function testTrustsForwardedProtoOnlyFromTrustedProxy(): void
+    {
+        $server = [
+            'REMOTE_ADDR' => '10.0.0.5',
+            'HTTP_X_FORWARDED_PROTO' => 'https, http',
+        ];
+
+        $this->assertTrue(TrustedProxy::isSecureRequest($server, '10.0.0.0/8'));
+        $this->assertFalse(TrustedProxy::isSecureRequest($server, '192.168.0.0/16'));
+    }
+
+    public function testDetectsHttpsPort(): void
+    {
+        $this->assertTrue(TrustedProxy::isSecureRequest(['SERVER_PORT' => '443']));
+    }
+}

--- a/CorianderCore/core/Http/RequestFactory.php
+++ b/CorianderCore/core/Http/RequestFactory.php
@@ -1,0 +1,57 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Core\Http;
+
+use Nyholm\Psr7\ServerRequest;
+
+final class RequestFactory
+{
+    /**
+     * @param array<string,mixed>|null $serverParams
+     * @param array<string,mixed>|null $postParams
+     * @param array<string,string>|null $headers
+     */
+    public static function fromGlobals(?array $serverParams = null, ?array $postParams = null, ?array $headers = null, ?string $rawBody = null): ServerRequest
+    {
+        $serverParams ??= $_SERVER;
+        $postParams ??= $_POST;
+        $headers ??= function_exists('getallheaders') ? getallheaders() : [];
+        $rawBody ??= (string) file_get_contents('php://input');
+
+        $protocol = (string) ($serverParams['SERVER_PROTOCOL'] ?? 'HTTP/1.1');
+        $version = str_contains($protocol, '/') ? substr($protocol, strpos($protocol, '/') + 1) : '1.1';
+
+        $request = new ServerRequest(
+            (string) ($serverParams['REQUEST_METHOD'] ?? 'GET'),
+            (string) ($serverParams['REQUEST_URI'] ?? '/'),
+            $headers,
+            $rawBody,
+            $version,
+            $serverParams
+        );
+
+        return self::withParsedBody($request, $serverParams, $headers, $postParams, $rawBody);
+    }
+
+    /**
+     * @param array<string,mixed> $serverParams
+     * @param array<string,string> $headers
+     * @param array<string,mixed> $postParams
+     */
+    private static function withParsedBody(ServerRequest $request, array $serverParams, array $headers, array $postParams, string $rawBody): ServerRequest
+    {
+        $method = strtoupper((string) ($serverParams['REQUEST_METHOD'] ?? 'GET'));
+        if (!in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
+            return $request;
+        }
+
+        $contentType = strtolower((string) ($headers['Content-Type'] ?? $headers['content-type'] ?? ''));
+        if (str_contains($contentType, 'application/json')) {
+            $decoded = json_decode($rawBody !== '' ? $rawBody : '', true);
+            return is_array($decoded) ? $request->withParsedBody($decoded) : $request;
+        }
+
+        return $postParams !== [] ? $request->withParsedBody($postParams) : $request;
+    }
+}

--- a/CorianderCore/core/Http/ResponseEmitter.php
+++ b/CorianderCore/core/Http/ResponseEmitter.php
@@ -1,0 +1,21 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Core\Http;
+
+use Psr\Http\Message\ResponseInterface;
+
+final class ResponseEmitter
+{
+    public static function emit(ResponseInterface $response): void
+    {
+        http_response_code($response->getStatusCode());
+        foreach ($response->getHeaders() as $name => $values) {
+            foreach ($values as $value) {
+                header($name . ': ' . $value, false);
+            }
+        }
+
+        echo $response->getBody();
+    }
+}

--- a/CorianderCore/core/Http/TrustedProxy.php
+++ b/CorianderCore/core/Http/TrustedProxy.php
@@ -1,0 +1,110 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Core\Http;
+
+final class TrustedProxy
+{
+    /**
+     * @param array<string,mixed> $serverParams
+     */
+    public static function isSecureRequest(array $serverParams, ?string $trustedProxies = null): bool
+    {
+        $https = strtolower((string) ($serverParams['HTTPS'] ?? ''));
+        if ($https !== '' && $https !== 'off' && $https !== '0') {
+            return true;
+        }
+
+        $remoteAddr = (string) ($serverParams['REMOTE_ADDR'] ?? '');
+        if (self::isTrustedProxy($remoteAddr, $trustedProxies)) {
+            $forwardedProto = strtolower((string) ($serverParams['HTTP_X_FORWARDED_PROTO'] ?? ''));
+            if ($forwardedProto !== '') {
+                $firstHop = trim(explode(',', $forwardedProto, 2)[0]);
+                if ($firstHop === 'https') {
+                    return true;
+                }
+            }
+
+            $forwarded = strtolower((string) ($serverParams['HTTP_FORWARDED'] ?? ''));
+            if ($forwarded !== '' && str_contains($forwarded, 'proto=https')) {
+                return true;
+            }
+
+            $forwardedSsl = strtolower((string) ($serverParams['HTTP_X_FORWARDED_SSL'] ?? ''));
+            if ($forwardedSsl === 'on') {
+                return true;
+            }
+
+            $frontEndHttps = strtolower((string) ($serverParams['HTTP_FRONT_END_HTTPS'] ?? ''));
+            if ($frontEndHttps === 'on') {
+                return true;
+            }
+        }
+
+        return (string) ($serverParams['SERVER_PORT'] ?? '') === '443';
+    }
+
+    private static function isTrustedProxy(string $remoteAddr, ?string $trustedProxies = null): bool
+    {
+        if ($remoteAddr === '') {
+            return false;
+        }
+
+        $trusted = $trustedProxies ?? (defined('TRUSTED_PROXIES') ? (string) TRUSTED_PROXIES : '127.0.0.1,::1');
+        $entries = array_map(static fn(string $item): string => trim($item), explode(',', $trusted));
+
+        foreach ($entries as $entry) {
+            if ($entry === '') {
+                continue;
+            }
+
+            if ($entry === '*') {
+                return true;
+            }
+
+            if (self::ipInCidr($remoteAddr, $entry)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static function ipInCidr(string $ip, string $cidr): bool
+    {
+        if (!str_contains($cidr, '/')) {
+            return $ip === $cidr;
+        }
+
+        [$subnet, $prefixLength] = explode('/', $cidr, 2);
+        if ($subnet === '' || !ctype_digit($prefixLength)) {
+            return false;
+        }
+
+        $ipBinary = @inet_pton($ip);
+        $subnetBinary = @inet_pton($subnet);
+        if ($ipBinary === false || $subnetBinary === false || strlen($ipBinary) !== strlen($subnetBinary)) {
+            return false;
+        }
+
+        $bits = (int) $prefixLength;
+        $maxBits = strlen($ipBinary) * 8;
+        if ($bits < 0 || $bits > $maxBits) {
+            return false;
+        }
+
+        $bytes = intdiv($bits, 8);
+        $remainder = $bits % 8;
+
+        if ($bytes > 0 && substr($ipBinary, 0, $bytes) !== substr($subnetBinary, 0, $bytes)) {
+            return false;
+        }
+
+        if ($remainder === 0) {
+            return true;
+        }
+
+        $mask = (0xFF << (8 - $remainder)) & 0xFF;
+        return (ord($ipBinary[$bytes]) & $mask) === (ord($subnetBinary[$bytes]) & $mask);
+    }
+}

--- a/public/index.php
+++ b/public/index.php
@@ -3,118 +3,15 @@
 use CorianderCore\Core\Bootstrap\TimezoneBootstrap;
 use CorianderCore\Core\Container\Container;
 use CorianderCore\Core\Database\DatabaseHandler;
+use CorianderCore\Core\Http\RequestFactory;
+use CorianderCore\Core\Http\ResponseEmitter;
+use CorianderCore\Core\Http\TrustedProxy;
 use CorianderCore\Core\Logging\Logger;
 use CorianderCore\Core\Router\Router;
 use CorianderCore\Core\Security\ApiRequestLimitsMiddleware;
 use CorianderCore\Core\Security\CsrfMiddleware;
 use CorianderCore\Core\Security\SecurityHeadersMiddleware;
 use Nyholm\Psr7\Response;
-use Nyholm\Psr7\ServerRequest;
-
-/**
- * Detect whether the original client connection should be treated as HTTPS.
- *
- * Supports direct HTTPS and common reverse proxy headers.
- */
-function corianderIpInCidr(string $ip, string $cidr): bool
-{
-    if (!str_contains($cidr, '/')) {
-        return $ip === $cidr;
-    }
-
-    [$subnet, $prefixLength] = explode('/', $cidr, 2);
-    if ($subnet === '' || !ctype_digit($prefixLength)) {
-        return false;
-    }
-
-    $ipBinary = @inet_pton($ip);
-    $subnetBinary = @inet_pton($subnet);
-    if ($ipBinary === false || $subnetBinary === false || strlen($ipBinary) !== strlen($subnetBinary)) {
-        return false;
-    }
-
-    $bits = (int) $prefixLength;
-    $maxBits = strlen($ipBinary) * 8;
-    if ($bits < 0 || $bits > $maxBits) {
-        return false;
-    }
-
-    $bytes = intdiv($bits, 8);
-    $remainder = $bits % 8;
-
-    if ($bytes > 0 && substr($ipBinary, 0, $bytes) !== substr($subnetBinary, 0, $bytes)) {
-        return false;
-    }
-
-    if ($remainder === 0) {
-        return true;
-    }
-
-    $mask = (0xFF << (8 - $remainder)) & 0xFF;
-    return (ord($ipBinary[$bytes]) & $mask) === (ord($subnetBinary[$bytes]) & $mask);
-}
-
-function corianderIsTrustedProxy(string $remoteAddr): bool
-{
-    if ($remoteAddr === '') {
-        return false;
-    }
-
-    $trusted = defined('TRUSTED_PROXIES') ? (string) TRUSTED_PROXIES : '127.0.0.1,::1';
-    $entries = array_map(static fn(string $item): string => trim($item), explode(',', $trusted));
-
-    foreach ($entries as $entry) {
-        if ($entry === '') {
-            continue;
-        }
-
-        if ($entry === '*') {
-            return true;
-        }
-
-        if (corianderIpInCidr($remoteAddr, $entry)) {
-            return true;
-        }
-    }
-
-    return false;
-}
-
-function corianderIsSecureRequest(array $serverParams): bool
-{
-    $https = strtolower((string) ($serverParams['HTTPS'] ?? ''));
-    if ($https !== '' && $https !== 'off' && $https !== '0') {
-        return true;
-    }
-
-    $remoteAddr = (string) ($serverParams['REMOTE_ADDR'] ?? '');
-    if (corianderIsTrustedProxy($remoteAddr)) {
-        $forwardedProto = strtolower((string) ($serverParams['HTTP_X_FORWARDED_PROTO'] ?? ''));
-        if ($forwardedProto !== '') {
-            $firstHop = trim(explode(',', $forwardedProto, 2)[0]);
-            if ($firstHop === 'https') {
-                return true;
-            }
-        }
-
-        $forwarded = strtolower((string) ($serverParams['HTTP_FORWARDED'] ?? ''));
-        if ($forwarded !== '' && str_contains($forwarded, 'proto=https')) {
-            return true;
-        }
-
-        $forwardedSsl = strtolower((string) ($serverParams['HTTP_X_FORWARDED_SSL'] ?? ''));
-        if ($forwardedSsl === 'on') {
-            return true;
-        }
-
-        $frontEndHttps = strtolower((string) ($serverParams['HTTP_FRONT_END_HTTPS'] ?? ''));
-        if ($frontEndHttps === 'on') {
-            return true;
-        }
-    }
-
-    return (string) ($serverParams['SERVER_PORT'] ?? '') === '443';
-}
 
 
 function corianderCreateNotFoundHandler(): callable
@@ -138,15 +35,6 @@ function corianderCreateNotFoundHandler(): callable
 }
 require_once '../config/config.php';
 
-$secure = corianderIsSecureRequest($_SERVER);
-session_set_cookie_params([
-    'path' => '/',
-    'secure' => $secure,
-    'httponly' => true,
-    'samesite' => 'Lax',
-]);
-session_start();
-
 if (file_exists(PROJECT_ROOT . '/CorianderCore/autoload.php')) {
     require_once PROJECT_ROOT . '/CorianderCore/autoload.php';
 }
@@ -154,6 +42,15 @@ if (file_exists(PROJECT_ROOT . '/CorianderCore/autoload.php')) {
 if (file_exists(PROJECT_ROOT . '/vendor/autoload.php')) {
     require_once PROJECT_ROOT . '/vendor/autoload.php';
 }
+
+$secure = TrustedProxy::isSecureRequest($_SERVER);
+session_set_cookie_params([
+    'path' => '/',
+    'secure' => $secure,
+    'httponly' => true,
+    'samesite' => 'Lax',
+]);
+session_start();
 
 $appTimezone = getenv('APP_TIMEZONE');
 TimezoneBootstrap::applyFromEnvironment(is_string($appTimezone) ? $appTimezone : null);
@@ -177,43 +74,7 @@ try {
         require $routesFile;
     }
 
-    $serverParams = $_SERVER;
-    $protocol = $serverParams['SERVER_PROTOCOL'] ?? 'HTTP/1.1';
-    $version = str_contains($protocol, '/') ? substr($protocol, strpos($protocol, '/') + 1) : '1.1';
-    $headers = function_exists('getallheaders') ? getallheaders() : [];
-    $rawBody = file_get_contents('php://input');
-
-    $request = new ServerRequest(
-        $serverParams['REQUEST_METHOD'] ?? 'GET',
-        $serverParams['REQUEST_URI'] ?? '/',
-        $headers,
-        $rawBody,
-        $version,
-        $serverParams
-    );
-
-    $contentType = strtolower((string) ($headers['Content-Type'] ?? $headers['content-type'] ?? ''));
-    $method = strtoupper($serverParams['REQUEST_METHOD'] ?? 'GET');
-    if (in_array($method, ['POST', 'PUT', 'PATCH', 'DELETE'], true)) {
-        if (str_contains($contentType, 'application/json')) {
-            $decoded = json_decode($rawBody ?: '', true);
-            if (is_array($decoded)) {
-                $request = $request->withParsedBody($decoded);
-            }
-        } elseif (!empty($_POST)) {
-            $request = $request->withParsedBody($_POST);
-        }
-    }
-
-    $response = $router->dispatch($request);
-
-    http_response_code($response->getStatusCode());
-    foreach ($response->getHeaders() as $name => $values) {
-        foreach ($values as $value) {
-            header($name . ': ' . $value, false);
-        }
-    }
-    echo $response->getBody();
+    ResponseEmitter::emit($router->dispatch(RequestFactory::fromGlobals()));
 } catch (Throwable $exception) {
     try {
         (new Logger())->error('Unhandled application exception.', ['exception' => $exception]);


### PR DESCRIPTION
## Summary
- Move trusted proxy/TLS detection out of `public/index.php` into `TrustedProxy`.
- Move PSR-7 request creation and parsed-body handling into `RequestFactory`.
- Move response emission into `ResponseEmitter`.
- Keep the front controller responsible for wiring, routing, and error handling.
- Add focused tests for trusted proxy detection and request creation.

## Tests
- `vendor\bin\phpunit --testdox`
- Result: `OK (164 tests, 360 assertions)`