### PR TITLE
Lazy-start sessions for stateless requests

### DIFF
--- a/CorianderCore/Tests/SessionBootstrapTest.php
+++ b/CorianderCore/Tests/SessionBootstrapTest.php
@@ -1,0 +1,40 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Tests;
+
+use CorianderCore\Core\Bootstrap\SessionBootstrap;
+use CorianderCore\Core\Security\Csrf;
+use PHPUnit\Framework\TestCase;
+
+class SessionBootstrapTest extends TestCase
+{
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testSkipsSessionStartForApiRequests(): void
+    {
+        SessionBootstrap::configure(false);
+        SessionBootstrap::startForRequest(['REQUEST_URI' => '/api/items']);
+
+        $this->assertSame(PHP_SESSION_NONE, session_status());
+    }
+
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testStartsSessionForWebRequests(): void
+    {
+        SessionBootstrap::configure(false);
+        SessionBootstrap::startForRequest(['REQUEST_URI' => '/home']);
+
+        $this->assertSame(PHP_SESSION_ACTIVE, session_status());
+    }
+
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testCsrfStartsSessionWhenTokenIsRequested(): void
+    {
+        SessionBootstrap::configure(false);
+
+        $token = Csrf::token();
+
+        $this->assertNotSame('', $token);
+        $this->assertSame(PHP_SESSION_ACTIVE, session_status());
+    }
+}

--- a/CorianderCore/core/Bootstrap/SessionBootstrap.php
+++ b/CorianderCore/core/Bootstrap/SessionBootstrap.php
@@ -1,0 +1,74 @@
+<?php
+declare(strict_types=1);
+
+namespace CorianderCore\Core\Bootstrap;
+
+final class SessionBootstrap
+{
+    /**
+     * @var array{path:string,secure:bool,httponly:bool,samesite:string}
+     */
+    private static array $cookieParams = [
+        'path' => '/',
+        'secure' => false,
+        'httponly' => true,
+        'samesite' => 'Lax',
+    ];
+
+    public static function configure(bool $secure): void
+    {
+        self::$cookieParams = [
+            'path' => '/',
+            'secure' => $secure,
+            'httponly' => true,
+            'samesite' => 'Lax',
+        ];
+    }
+
+    /**
+     * @param array<string,mixed> $serverParams
+     * @param string[] $statelessPrefixes
+     */
+    public static function startForRequest(array $serverParams, array $statelessPrefixes = ['api']): void
+    {
+        if (self::isStatelessRequest($serverParams, $statelessPrefixes)) {
+            return;
+        }
+
+        self::start();
+    }
+
+    public static function start(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            return;
+        }
+
+        session_set_cookie_params(self::$cookieParams);
+        session_start();
+    }
+
+    /**
+     * @param array<string,mixed> $serverParams
+     * @param string[] $statelessPrefixes
+     */
+    private static function isStatelessRequest(array $serverParams, array $statelessPrefixes): bool
+    {
+        $uri = (string) ($serverParams['REQUEST_URI'] ?? '/');
+        $path = parse_url($uri, PHP_URL_PATH);
+        $normalizedPath = trim(is_string($path) ? $path : '/', '/');
+
+        foreach ($statelessPrefixes as $prefix) {
+            $normalizedPrefix = trim($prefix, '/');
+            if ($normalizedPrefix === '') {
+                continue;
+            }
+
+            if ($normalizedPath === $normalizedPrefix || str_starts_with($normalizedPath, $normalizedPrefix . '/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+}

--- a/CorianderCore/core/Security/Csrf.php
+++ b/CorianderCore/core/Security/Csrf.php
@@ -3,6 +3,8 @@ declare(strict_types=1);
 
 namespace CorianderCore\Core\Security;
 
+use CorianderCore\Core\Bootstrap\SessionBootstrap;
+
 /**
  * Handles generation, storage, and validation of CSRF tokens.
  *
@@ -22,9 +24,7 @@ class Csrf
      */
     public static function token(): string
     {
-        if (session_status() !== PHP_SESSION_ACTIVE) {
-            session_start();
-        }
+        SessionBootstrap::start();
 
         if (empty($_SESSION[self::SESSION_KEY])) {
             $_SESSION[self::SESSION_KEY] = bin2hex(random_bytes(32));
@@ -52,9 +52,7 @@ class Csrf
      */
     public static function validate(?string $token): bool
     {
-        if (session_status() !== PHP_SESSION_ACTIVE) {
-            session_start();
-        }
+        SessionBootstrap::start();
 
         $sessionToken = $_SESSION[self::SESSION_KEY] ?? '';
         return $sessionToken !== '' && $token !== null && hash_equals($sessionToken, $token);

--- a/public/index.php
+++ b/public/index.php
@@ -1,5 +1,6 @@
 <?php
 
+use CorianderCore\Core\Bootstrap\SessionBootstrap;
 use CorianderCore\Core\Bootstrap\TimezoneBootstrap;
 use CorianderCore\Core\Container\Container;
 use CorianderCore\Core\Database\DatabaseHandler;
@@ -44,13 +45,8 @@ if (file_exists(PROJECT_ROOT . '/vendor/autoload.php')) {
 }
 
 $secure = TrustedProxy::isSecureRequest($_SERVER);
-session_set_cookie_params([
-    'path' => '/',
-    'secure' => $secure,
-    'httponly' => true,
-    'samesite' => 'Lax',
-]);
-session_start();
+SessionBootstrap::configure($secure);
+SessionBootstrap::startForRequest($_SERVER);
 
 $appTimezone = getenv('APP_TIMEZONE');
 TimezoneBootstrap::applyFromEnvironment(is_string($appTimezone) ? $appTimezone : null);


### PR DESCRIPTION
## Summary
- Add `SessionBootstrap` to centralize session cookie configuration and startup.
- Avoid starting sessions for `/api/*` requests during bootstrap.
- Keep web requests session-compatible by starting sessions for non-API paths.
- Route CSRF token generation and validation through `SessionBootstrap` so sessions still start when CSRF needs them.
- Add tests for API skip behavior, web startup, and CSRF-triggered session startup.

## Tests
- `vendor\bin\phpunit --testdox`
- Result: `OK (161 tests, 354 assertions)`