### PR TITLE
Route safe SQL helpers away from deprecated paths

### DIFF
--- a/CorianderCore/Tests/SQLManagerTest.php
+++ b/CorianderCore/Tests/SQLManagerTest.php
@@ -42,18 +42,9 @@ class SQLManagerTest extends TestCase
 
     public function testFindAllSupportsWildcardColumn(): void
     {
-        $pdo = new \PDO('sqlite::memory:');
-        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo = $this->createSqliteHandler();
         $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)');
         $pdo->exec("INSERT INTO users (name) VALUES ('alice')");
-
-        $handler = new DatabaseHandler();
-        $reflection = new \ReflectionClass($handler);
-        $pdoProperty = $reflection->getProperty('pdo');
-        $pdoProperty->setAccessible(true);
-        $pdoProperty->setValue($handler, $pdo);
-
-        SQLManager::setDatabaseHandler($handler);
 
         $rows = SQLManager::findAll(['*'], 'users');
 
@@ -63,23 +54,44 @@ class SQLManagerTest extends TestCase
 
     public function testFindAllSupportsTableOnlySignature(): void
     {
-        $pdo = new \PDO('sqlite::memory:');
-        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+        $pdo = $this->createSqliteHandler();
         $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)');
         $pdo->exec("INSERT INTO users (name) VALUES ('bob')");
-
-        $handler = new DatabaseHandler();
-        $reflection = new \ReflectionClass($handler);
-        $pdoProperty = $reflection->getProperty('pdo');
-        $pdoProperty->setAccessible(true);
-        $pdoProperty->setValue($handler, $pdo);
-
-        SQLManager::setDatabaseHandler($handler);
 
         $rows = SQLManager::findAll('users');
 
         $this->assertCount(1, $rows);
         $this->assertSame('bob', $rows[0]['name']);
+    }
+
+    public function testSafeWhereMethodsDoNotTriggerDeprecatedRawMethods(): void
+    {
+        $pdo = $this->createSqliteHandler();
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT)');
+        $pdo->exec("INSERT INTO users (name) VALUES ('alice')");
+
+        $deprecations = 0;
+        set_error_handler(static function (int $severity) use (&$deprecations): bool {
+            if ($severity === E_USER_DEPRECATED) {
+                $deprecations++;
+            }
+
+            return true;
+        });
+
+        try {
+            $rows = SQLManager::findWhere(['id', 'name'], 'users', ['name' => 'alice']);
+            $updated = SQLManager::updateWhere('users', ['name' => 'bob'], ['id' => 1]);
+            $deleted = SQLManager::deleteWhere('users', ['name' => 'bob']);
+        } finally {
+            restore_error_handler();
+        }
+
+        $this->assertSame(0, $deprecations);
+        $this->assertSame([['id' => 1, 'name' => 'alice']], $rows);
+        $this->assertTrue($updated);
+        $this->assertTrue($deleted);
+        $this->assertSame([], SQLManager::findAll('users'));
     }
 
     public function testBuildColumnListSupportsQualifiedWildcard(): void
@@ -99,5 +111,21 @@ class SQLManagerTest extends TestCase
 
         $this->expectException(DatabaseException::class);
         $method->invoke(null, '');
+    }
+
+    private function createSqliteHandler(): \PDO
+    {
+        $pdo = new \PDO('sqlite::memory:');
+        $pdo->setAttribute(\PDO::ATTR_ERRMODE, \PDO::ERRMODE_EXCEPTION);
+
+        $handler = new DatabaseHandler();
+        $reflection = new \ReflectionClass($handler);
+        $pdoProperty = $reflection->getProperty('pdo');
+        $pdoProperty->setAccessible(true);
+        $pdoProperty->setValue($handler, $pdo);
+
+        SQLManager::setDatabaseHandler($handler);
+
+        return $pdo;
     }
 }

--- a/CorianderCore/core/Database/SQLManager.php
+++ b/CorianderCore/core/Database/SQLManager.php
@@ -147,15 +147,7 @@ class SQLManager
     {
         @trigger_error('SQLManager::findBy() is deprecated. Use findWhere() for simple equality conditions.', E_USER_DEPRECATED);
         try {
-            $pdo = self::requirePdo();
-            $columnList = self::buildColumnList($columns);
-            $table = self::quoteIdentifier($table);
-            $sql = sprintf('SELECT %s FROM %s WHERE %s', $columnList, $table, $where);
-            $stmt = $pdo->prepare($sql);
-            $stmt->execute($params);
-            $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
-
-            return $data !== false ? $data : [];
+            return self::selectRows($columns, $table, $where, $params);
         } catch (Exception $e) {
             self::getLogger()->error('[SQLManager] findBy exception', ['exception' => $e]);
             throw new DatabaseException('Unable to execute findBy query.', 0, $e);
@@ -170,7 +162,13 @@ class SQLManager
     public static function findWhere(array $columns, string $table, array $conditions): array
     {
         [$whereClause, $params] = self::buildWhereFromArray($conditions, 'w_');
-        return self::findBy($columns, $table, $whereClause, $params);
+
+        try {
+            return self::selectRows($columns, $table, $whereClause, $params);
+        } catch (Exception $e) {
+            self::getLogger()->error('[SQLManager] findWhere exception', ['exception' => $e]);
+            throw new DatabaseException('Unable to execute findWhere query.', 0, $e);
+        }
     }
 
     /**
@@ -191,19 +189,7 @@ class SQLManager
     {
         @trigger_error('SQLManager::update() is deprecated. Use updateWhere() for simple equality conditions.', E_USER_DEPRECATED);
         try {
-            $pdo = self::requirePdo();
-            $table = self::quoteIdentifier($table);
-            $set = [];
-            foreach ($data as $column => $value) {
-                $placeholder = ':' . $column;
-                $set[] = sprintf('%s = %s', self::quoteIdentifier((string) $column), $placeholder);
-                $params[$column] = $value;
-            }
-            $sql = sprintf('UPDATE %s SET %s WHERE %s', $table, implode(', ', $set), $where);
-            $stmt = $pdo->prepare($sql);
-            $stmt->execute($params);
-
-            return true;
+            return self::updateRows($table, $data, $where, $params);
         } catch (Exception $e) {
             self::getLogger()->error('[SQLManager] update exception', ['exception' => $e]);
             throw new DatabaseException('Unable to execute update query.', 0, $e);
@@ -219,7 +205,13 @@ class SQLManager
     public static function updateWhere(string $table, array $data, array $conditions): bool
     {
         [$whereClause, $whereParams] = self::buildWhereFromArray($conditions, 'w_');
-        return self::update($table, $data, $whereClause, $whereParams);
+
+        try {
+            return self::updateRows($table, $data, $whereClause, $whereParams);
+        } catch (Exception $e) {
+            self::getLogger()->error('[SQLManager] updateWhere exception', ['exception' => $e]);
+            throw new DatabaseException('Unable to execute updateWhere query.', 0, $e);
+        }
     }
 
     /**
@@ -295,15 +287,7 @@ class SQLManager
     {
         @trigger_error('SQLManager::deleteFrom() is deprecated. Use deleteWhere() for simple equality conditions.', E_USER_DEPRECATED);
         try {
-            $pdo = self::requirePdo();
-            $table = self::quoteIdentifier($table);
-            $sql = $where === ''
-                ? sprintf('DELETE FROM %s', $table)
-                : sprintf('DELETE FROM %s WHERE %s', $table, $where);
-            $stmt = $pdo->prepare($sql);
-            $stmt->execute($params);
-
-            return true;
+            return self::deleteRows($table, $where, $params);
         } catch (Exception $e) {
             self::getLogger()->error('[SQLManager] deleteFrom exception', ['exception' => $e]);
             throw new DatabaseException('Unable to execute delete query.', 0, $e);
@@ -318,7 +302,13 @@ class SQLManager
     public static function deleteWhere(string $table, array $conditions): bool
     {
         [$whereClause, $params] = self::buildWhereFromArray($conditions, 'w_');
-        return self::deleteFrom($table, $whereClause, $params);
+
+        try {
+            return self::deleteRows($table, $whereClause, $params);
+        } catch (Exception $e) {
+            self::getLogger()->error('[SQLManager] deleteWhere exception', ['exception' => $e]);
+            throw new DatabaseException('Unable to execute deleteWhere query.', 0, $e);
+        }
     }
 
     /**
@@ -376,6 +366,62 @@ class SQLManager
         }
 
         return [implode(' AND ', $clauses), $params];
+    }
+
+    /**
+     * @param array<int,string> $columns
+     * @param array<string,mixed> $params
+     */
+    private static function selectRows(array $columns, string $table, string $where, array $params = []): array
+    {
+        $pdo = self::requirePdo();
+        $columnList = self::buildColumnList($columns);
+        $table = self::quoteIdentifier($table);
+        $sql = sprintf('SELECT %s FROM %s WHERE %s', $columnList, $table, $where);
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+        $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+        return $data !== false ? $data : [];
+    }
+
+    /**
+     * @param array<string,mixed> $data
+     * @param array<string,mixed> $params
+     */
+    private static function updateRows(string $table, array $data, string $where, array $params = []): bool
+    {
+        $pdo = self::requirePdo();
+        $table = self::quoteIdentifier($table);
+        $set = [];
+
+        foreach ($data as $column => $value) {
+            $placeholder = ':' . $column;
+            $set[] = sprintf('%s = %s', self::quoteIdentifier((string) $column), $placeholder);
+            $params[$column] = $value;
+        }
+
+        $sql = sprintf('UPDATE %s SET %s WHERE %s', $table, implode(', ', $set), $where);
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+
+        return true;
+    }
+
+    /**
+     * @param array<string,mixed> $params
+     */
+    private static function deleteRows(string $table, string $where = '', array $params = []): bool
+    {
+        $pdo = self::requirePdo();
+        $table = self::quoteIdentifier($table);
+        $sql = $where === ''
+            ? sprintf('DELETE FROM %s', $table)
+            : sprintf('DELETE FROM %s WHERE %s', $table, $where);
+        $stmt = $pdo->prepare($sql);
+        $stmt->execute($params);
+
+        return true;
     }
 
     /**


### PR DESCRIPTION
## Summary
- Extract shared SQL execution helpers for select, update, and delete operations.
- Keep deprecated raw-condition methods available while routing `findWhere`, `updateWhere`, and `deleteWhere` directly through the shared helpers.
- Add a regression test proving safe where methods do not trigger deprecated raw-method warnings.

## Tests
- vendor\bin\phpunit --testdox CorianderCore\Tests\SQLManagerTest.php
- vendor\bin\phpunit --testdox