### PR TITLE
Scope database close policy per handler

### DIFF
--- a/CorianderCore/Tests/DatabaseHandlerTest.php
+++ b/CorianderCore/Tests/DatabaseHandlerTest.php
@@ -8,6 +8,11 @@ use PHPUnit\Framework\TestCase;
 
 class DatabaseHandlerTest extends TestCase
 {
+    protected function tearDown(): void
+    {
+        DatabaseHandler::setAutoCloseConnection(true);
+    }
+
     public function testBuildMysqlDsnIncludesPortAndProvidedCharset(): void
     {
         $dsn = DatabaseHandler::buildMysqlDsn('localhost', 'app_db', 3307, 'latin1');
@@ -20,5 +25,47 @@ class DatabaseHandlerTest extends TestCase
         $dsn = DatabaseHandler::buildMysqlDsn('127.0.0.1', 'app_db', 0, '');
 
         $this->assertSame('mysql:host=127.0.0.1;dbname=app_db;charset=utf8mb4', $dsn);
+    }
+
+    public function testCloseUsesInstanceAutoCloseSetting(): void
+    {
+        $handler = new DatabaseHandler(null, false);
+        $pdo = new \PDO('sqlite::memory:');
+        $this->injectPdo($handler, $pdo);
+
+        $handler->close();
+
+        $this->assertSame($pdo, $handler->getPDO());
+
+        $handler->setAutoClose(true);
+        $handler->close();
+
+        $this->assertNull($handler->getPDO());
+    }
+
+    public function testStaticAutoCloseSetterOnlyChangesNewHandlerDefault(): void
+    {
+        $existingHandler = new DatabaseHandler(null, false);
+        $existingPdo = new \PDO('sqlite::memory:');
+        $this->injectPdo($existingHandler, $existingPdo);
+
+        DatabaseHandler::setAutoCloseConnection(true);
+        $newHandler = new DatabaseHandler();
+        $newPdo = new \PDO('sqlite::memory:');
+        $this->injectPdo($newHandler, $newPdo);
+
+        $existingHandler->close();
+        $newHandler->close();
+
+        $this->assertSame($existingPdo, $existingHandler->getPDO());
+        $this->assertNull($newHandler->getPDO());
+    }
+
+    private function injectPdo(DatabaseHandler $handler, \PDO $pdo): void
+    {
+        $reflection = new \ReflectionClass($handler);
+        $pdoProperty = $reflection->getProperty('pdo');
+        $pdoProperty->setAccessible(true);
+        $pdoProperty->setValue($handler, $pdo);
     }
 }

--- a/CorianderCore/core/Database/DatabaseHandler.php
+++ b/CorianderCore/core/Database/DatabaseHandler.php
@@ -40,7 +40,12 @@ class DatabaseHandler
     /**
      * @var bool Auto-close flag to determine if the connection should close automatically.
      */
-    private static bool $autoCloseConnection = true;
+    private static bool $defaultAutoCloseConnection = true;
+
+    /**
+     * @var bool Whether this handler should close its PDO connection on close().
+     */
+    private bool $autoCloseConnection;
 
     /**
      * Construct a new DatabaseHandler instance.
@@ -49,9 +54,10 @@ class DatabaseHandler
      *
      * @param LoggerInterface|null $logger Logger instance for reporting issues; defaults to core Logger when null.
      */
-    public function __construct(?LoggerInterface $logger = null)
+    public function __construct(?LoggerInterface $logger = null, ?bool $autoCloseConnection = null)
     {
         $this->logger = $logger ?? new Logger();
+        $this->autoCloseConnection = $autoCloseConnection ?? self::$defaultAutoCloseConnection;
 
         if (!defined('DB_TYPE')) {
             $this->logger->warning('DB_TYPE is not defined. No database connection established.');
@@ -121,7 +127,18 @@ class DatabaseHandler
      */
     public static function setAutoCloseConnection(bool $autoClose): void
     {
-        self::$autoCloseConnection = $autoClose;
+        self::$defaultAutoCloseConnection = $autoClose;
+    }
+
+    /**
+     * Set whether this handler instance should close its connection.
+     *
+     * @param bool $autoClose Whether this instance should close its PDO connection.
+     * @return void
+     */
+    public function setAutoClose(bool $autoClose): void
+    {
+        $this->autoCloseConnection = $autoClose;
     }
 
     /**
@@ -132,7 +149,7 @@ class DatabaseHandler
      */
     public function close(): void
     {
-        if (!self::$autoCloseConnection) {
+        if (!$this->autoCloseConnection) {
             return;
         }
         $this->pdo = null;


### PR DESCRIPTION
## Summary
- Move database auto-close behavior from shared mutable state to each `DatabaseHandler` instance.
- Preserve `DatabaseHandler::setAutoCloseConnection()` as a backward-compatible default for new handlers.
- Add tests for instance-level close behavior and the static default compatibility path.

## Tests
- vendor\bin\phpunit --testdox CorianderCore\Tests\DatabaseHandlerTest.php
- vendor\bin\phpunit --testdox