### PR TITLE
Add route parameter constraints

### DIFF
--- a/CorianderCore/core/Router/Router.php
+++ b/CorianderCore/core/Router/Router.php
@@ -81,18 +81,38 @@ class Router
             $pattern = trim($prefix . '/' . $pattern, '/');
         }
 
-        $paramNames = [];
-        if (preg_match_all('#\{([^}]+)\}#', $pattern, $matches)) {
-            $paramNames = $matches[1];
-        }
-
-        $regex = preg_quote($pattern, '#');
-        $regex = preg_replace('#\\\{([^/]+)\\\}#', '([^/]+)', $regex);
-        $regex = '#^' . $regex . '$#';
+        [$regex, $paramNames] = $this->compileRoutePattern($pattern);
 
         $middleware = array_merge($this->getGroupMiddleware(), $middleware);
 
         $this->registry->add(strtoupper($method), $regex, $paramNames, $callback, $middleware);
+    }
+
+    /**
+     * @return array{0:string,1:array<int,string>}
+     */
+    private function compileRoutePattern(string $pattern): array
+    {
+        $paramNames = [];
+        $regex = '';
+        $offset = 0;
+
+        preg_match_all('#\{([^}:\/]+)(?::([^}]+))?\}#', $pattern, $matches, PREG_OFFSET_CAPTURE);
+
+        foreach ($matches[0] as $index => $match) {
+            [$token, $position] = $match;
+            $regex .= preg_quote(substr($pattern, $offset, $position - $offset), '#');
+
+            $paramNames[] = $matches[1][$index][0];
+            $constraint = $matches[2][$index][1] >= 0 ? $matches[2][$index][0] : '[^/]+';
+            $regex .= '(' . $constraint . ')';
+
+            $offset = $position + strlen($token);
+        }
+
+        $regex .= preg_quote(substr($pattern, $offset), '#');
+
+        return ['#^' . $regex . '$#', $paramNames];
     }
 
     /**

--- a/CorianderCore/tests/RouterTest.php
+++ b/CorianderCore/tests/RouterTest.php
@@ -379,6 +379,40 @@ class RouterTest extends TestCase
     }
 
     /**
+     * Test that route parameters can define regex constraints.
+     */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testRouteParameterConstraints(): void
+    {
+        $this->router->add('GET', '/user/{id:\d+}', function (ServerRequest $request) {
+            return 'User ' . $request->getAttribute('id');
+        });
+
+        $validResponse = $this->router->dispatch(new ServerRequest('GET', '/user/123'));
+        $invalidResponse = $this->router->dispatch(new ServerRequest('GET', '/user/abc'));
+
+        $this->assertSame('User 123', (string) $validResponse->getBody());
+        $this->assertSame(404, $invalidResponse->getStatusCode());
+    }
+
+    /**
+     * Test that shortcut routes support constrained route parameters.
+     */
+    #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]
+    public function testShortcutRoutesSupportParameterConstraints(): void
+    {
+        $this->router->get('/posts/{slug:[a-z0-9-]+}', function (ServerRequest $request) {
+            return $request->getAttribute('slug');
+        });
+
+        $validResponse = $this->router->dispatch(new ServerRequest('GET', '/posts/hello-world'));
+        $invalidResponse = $this->router->dispatch(new ServerRequest('GET', '/posts/Hello'));
+
+        $this->assertSame('hello-world', (string) $validResponse->getBody());
+        $this->assertSame(404, $invalidResponse->getStatusCode());
+    }
+
+    /**
      * Test that a route returns 405 when the path matches but the method does not.
      */
     #[\PHPUnit\Framework\Attributes\RunInSeparateProcess]


### PR DESCRIPTION
## Summary
- Add support for constrained route parameters like `{id:\d+}` while preserving existing `{id}` behavior.
- Keep parameter extraction compatible with route callbacks.
- Cover constrained matching and shortcut route registration with router tests.

## Tests
- vendor\bin\phpunit --testdox CorianderCore\Tests\RouterTest.php CorianderCore\Tests\RouterIntegrationTest.php
- vendor\bin\phpunit --testdox