### PR TITLE
Guard repeated env file loads

### DIFF
--- a/CorianderCore/Tests/EnvLoaderTest.php
+++ b/CorianderCore/Tests/EnvLoaderTest.php
@@ -22,6 +22,8 @@ class EnvLoaderTest extends TestCase
         'ENV_LOADER_INLINE',
         'ENV_LOADER_EXPORTED',
         'ENV_LOADER_EXISTING',
+        'ENV_LOADER_RELOAD',
+        'ENV_LOADER_OVERWRITE_RELOAD',
     ];
 
     protected function setUp(): void
@@ -80,6 +82,34 @@ class EnvLoaderTest extends TestCase
         EnvLoader::load($this->tempRoot, overwrite: true);
 
         $this->assertSame('file', getenv('ENV_LOADER_EXISTING'));
+    }
+
+    public function testSkipsAlreadyLoadedPathWithoutOverwrite(): void
+    {
+        file_put_contents($this->tempRoot . '/.env', 'ENV_LOADER_RELOAD=first');
+
+        EnvLoader::load($this->tempRoot);
+        putenv('ENV_LOADER_RELOAD');
+        unset($_ENV['ENV_LOADER_RELOAD'], $_SERVER['ENV_LOADER_RELOAD']);
+        file_put_contents($this->tempRoot . '/.env', 'ENV_LOADER_RELOAD=second');
+
+        EnvLoader::load($this->tempRoot);
+
+        $this->assertFalse(getenv('ENV_LOADER_RELOAD'));
+        $this->assertArrayNotHasKey('ENV_LOADER_RELOAD', $_ENV);
+        $this->assertArrayNotHasKey('ENV_LOADER_RELOAD', $_SERVER);
+    }
+
+    public function testOverwriteReloadsAlreadyLoadedPath(): void
+    {
+        file_put_contents($this->tempRoot . '/.env', 'ENV_LOADER_OVERWRITE_RELOAD=first');
+
+        EnvLoader::load($this->tempRoot);
+        file_put_contents($this->tempRoot . '/.env', 'ENV_LOADER_OVERWRITE_RELOAD=second');
+
+        EnvLoader::load($this->tempRoot, overwrite: true);
+
+        $this->assertSame('second', getenv('ENV_LOADER_OVERWRITE_RELOAD'));
     }
 
     private function clearVariables(): void

--- a/CorianderCore/core/Bootstrap/EnvLoader.php
+++ b/CorianderCore/core/Bootstrap/EnvLoader.php
@@ -5,6 +5,11 @@ namespace CorianderCore\Core\Bootstrap;
 
 final class EnvLoader
 {
+    /**
+     * @var array<string, true>
+     */
+    private static array $loadedPaths = [];
+
     public static function load(string $projectRoot, bool $createFromExample = true, bool $overwrite = false): void
     {
         $projectRoot = rtrim(str_replace('\\', '/', $projectRoot), '/');
@@ -19,6 +24,11 @@ final class EnvLoader
             return;
         }
 
+        $loadedPath = str_replace('\\', '/', realpath($envPath) ?: $envPath);
+        if (!$overwrite && isset(self::$loadedPaths[$loadedPath])) {
+            return;
+        }
+
         $lines = file($envPath, FILE_IGNORE_NEW_LINES);
         if ($lines === false) {
             return;
@@ -27,6 +37,8 @@ final class EnvLoader
         foreach ($lines as $line) {
             self::loadLine($line, $overwrite);
         }
+
+        self::$loadedPaths[$loadedPath] = true;
     }
 
     private static function loadLine(string $line, bool $overwrite): void


### PR DESCRIPTION
## Summary
- Track loaded `.env` paths to avoid reparsing the same file on repeated bootstrap calls.
- Keep `overwrite: true` as an explicit reload path.
- Add tests for skipped repeated loads and forced overwrite reloads.

## Tests
- vendor\bin\phpunit --testdox CorianderCore\Tests\EnvLoaderTest.php
- vendor\bin\phpunit --testdox