### PR TITLE
Normalize test env fixture names

### DIFF
--- a/CorianderCore/Tests/EnvLoaderTest.php
+++ b/CorianderCore/Tests/EnvLoaderTest.php
@@ -17,13 +17,13 @@ class EnvLoaderTest extends TestCase
      * @var string[]
      */
     private array $variables = [
-        'ENV_LOADER_SIMPLE',
-        'ENV_LOADER_QUOTED',
-        'ENV_LOADER_INLINE',
-        'ENV_LOADER_EXPORTED',
-        'ENV_LOADER_EXISTING',
-        'ENV_LOADER_RELOAD',
-        'ENV_LOADER_OVERWRITE_RELOAD',
+        'CORIANDER_TEST_ENV_LOADER_SIMPLE',
+        'CORIANDER_TEST_ENV_LOADER_QUOTED',
+        'CORIANDER_TEST_ENV_LOADER_INLINE',
+        'CORIANDER_TEST_ENV_LOADER_EXPORTED',
+        'CORIANDER_TEST_ENV_LOADER_EXISTING',
+        'CORIANDER_TEST_ENV_LOADER_RELOAD',
+        'CORIANDER_TEST_ENV_LOADER_OVERWRITE_RELOAD',
     ];
 
     protected function setUp(): void
@@ -44,72 +44,72 @@ class EnvLoaderTest extends TestCase
             $this->tempRoot . '/.env-example',
             implode(PHP_EOL, [
                 '# Local variables',
-                'ENV_LOADER_SIMPLE=value',
-                'ENV_LOADER_QUOTED="hello world"',
-                'ENV_LOADER_INLINE=value # comment',
-                'export ENV_LOADER_EXPORTED=yes',
+                'CORIANDER_TEST_ENV_LOADER_SIMPLE=value',
+                'CORIANDER_TEST_ENV_LOADER_QUOTED="hello world"',
+                'CORIANDER_TEST_ENV_LOADER_INLINE=value # comment',
+                'export CORIANDER_TEST_ENV_LOADER_EXPORTED=yes',
             ])
         );
 
         EnvLoader::load($this->tempRoot);
 
         $this->assertFileExists($this->tempRoot . '/.env');
-        $this->assertSame('value', getenv('ENV_LOADER_SIMPLE'));
-        $this->assertSame('hello world', getenv('ENV_LOADER_QUOTED'));
-        $this->assertSame('value', getenv('ENV_LOADER_INLINE'));
-        $this->assertSame('yes', getenv('ENV_LOADER_EXPORTED'));
-        $this->assertSame('value', $_ENV['ENV_LOADER_SIMPLE']);
-        $this->assertSame('value', $_SERVER['ENV_LOADER_SIMPLE']);
+        $this->assertSame('value', getenv('CORIANDER_TEST_ENV_LOADER_SIMPLE'));
+        $this->assertSame('hello world', getenv('CORIANDER_TEST_ENV_LOADER_QUOTED'));
+        $this->assertSame('value', getenv('CORIANDER_TEST_ENV_LOADER_INLINE'));
+        $this->assertSame('yes', getenv('CORIANDER_TEST_ENV_LOADER_EXPORTED'));
+        $this->assertSame('value', $_ENV['CORIANDER_TEST_ENV_LOADER_SIMPLE']);
+        $this->assertSame('value', $_SERVER['CORIANDER_TEST_ENV_LOADER_SIMPLE']);
     }
 
     public function testDoesNotOverwriteExistingEnvironmentByDefault(): void
     {
-        putenv('ENV_LOADER_EXISTING=server');
+        putenv('CORIANDER_TEST_ENV_LOADER_EXISTING=server');
 
-        file_put_contents($this->tempRoot . '/.env', 'ENV_LOADER_EXISTING=file');
+        file_put_contents($this->tempRoot . '/.env', 'CORIANDER_TEST_ENV_LOADER_EXISTING=file');
 
         EnvLoader::load($this->tempRoot);
 
-        $this->assertSame('server', getenv('ENV_LOADER_EXISTING'));
+        $this->assertSame('server', getenv('CORIANDER_TEST_ENV_LOADER_EXISTING'));
     }
 
     public function testCanOverwriteExistingEnvironmentWhenRequested(): void
     {
-        putenv('ENV_LOADER_EXISTING=server');
+        putenv('CORIANDER_TEST_ENV_LOADER_EXISTING=server');
 
-        file_put_contents($this->tempRoot . '/.env', 'ENV_LOADER_EXISTING=file');
+        file_put_contents($this->tempRoot . '/.env', 'CORIANDER_TEST_ENV_LOADER_EXISTING=file');
 
         EnvLoader::load($this->tempRoot, overwrite: true);
 
-        $this->assertSame('file', getenv('ENV_LOADER_EXISTING'));
+        $this->assertSame('file', getenv('CORIANDER_TEST_ENV_LOADER_EXISTING'));
     }
 
     public function testSkipsAlreadyLoadedPathWithoutOverwrite(): void
     {
-        file_put_contents($this->tempRoot . '/.env', 'ENV_LOADER_RELOAD=first');
+        file_put_contents($this->tempRoot . '/.env', 'CORIANDER_TEST_ENV_LOADER_RELOAD=first');
 
         EnvLoader::load($this->tempRoot);
-        putenv('ENV_LOADER_RELOAD');
-        unset($_ENV['ENV_LOADER_RELOAD'], $_SERVER['ENV_LOADER_RELOAD']);
-        file_put_contents($this->tempRoot . '/.env', 'ENV_LOADER_RELOAD=second');
+        putenv('CORIANDER_TEST_ENV_LOADER_RELOAD');
+        unset($_ENV['CORIANDER_TEST_ENV_LOADER_RELOAD'], $_SERVER['CORIANDER_TEST_ENV_LOADER_RELOAD']);
+        file_put_contents($this->tempRoot . '/.env', 'CORIANDER_TEST_ENV_LOADER_RELOAD=second');
 
         EnvLoader::load($this->tempRoot);
 
-        $this->assertFalse(getenv('ENV_LOADER_RELOAD'));
-        $this->assertArrayNotHasKey('ENV_LOADER_RELOAD', $_ENV);
-        $this->assertArrayNotHasKey('ENV_LOADER_RELOAD', $_SERVER);
+        $this->assertFalse(getenv('CORIANDER_TEST_ENV_LOADER_RELOAD'));
+        $this->assertArrayNotHasKey('CORIANDER_TEST_ENV_LOADER_RELOAD', $_ENV);
+        $this->assertArrayNotHasKey('CORIANDER_TEST_ENV_LOADER_RELOAD', $_SERVER);
     }
 
     public function testOverwriteReloadsAlreadyLoadedPath(): void
     {
-        file_put_contents($this->tempRoot . '/.env', 'ENV_LOADER_OVERWRITE_RELOAD=first');
+        file_put_contents($this->tempRoot . '/.env', 'CORIANDER_TEST_ENV_LOADER_OVERWRITE_RELOAD=first');
 
         EnvLoader::load($this->tempRoot);
-        file_put_contents($this->tempRoot . '/.env', 'ENV_LOADER_OVERWRITE_RELOAD=second');
+        file_put_contents($this->tempRoot . '/.env', 'CORIANDER_TEST_ENV_LOADER_OVERWRITE_RELOAD=second');
 
         EnvLoader::load($this->tempRoot, overwrite: true);
 
-        $this->assertSame('second', getenv('ENV_LOADER_OVERWRITE_RELOAD'));
+        $this->assertSame('second', getenv('CORIANDER_TEST_ENV_LOADER_OVERWRITE_RELOAD'));
     }
 
     private function clearVariables(): void


### PR DESCRIPTION
## Summary
- Rename env loader test-only fixture variables to use the `CORIANDER_TEST_*` prefix.
- Keep real framework/user environment variables unchanged in tests where they intentionally verify public behavior.

## Why
The previous `ENV_LOADER_*` fixture names could look like framework-level environment options. Prefixing them with `CORIANDER_TEST_*` makes it clear they are private test fixtures and not developer-facing configuration.

## Validation
- `vendor\bin\phpunit --testdox CorianderCore\Tests\EnvLoaderTest.php`
- `vendor\bin\phpunit --testdox`