### PR TITLE
Expand sqlScript custom SQL results

### DIFF
--- a/CorianderCore/Tests/SQLManagerTest.php
+++ b/CorianderCore/Tests/SQLManagerTest.php
@@ -94,6 +94,70 @@ class SQLManagerTest extends TestCase
         $this->assertSame([], SQLManager::findAll('users'));
     }
 
+    public function testSqlScriptReturnsAllRowsForCustomSelect(): void
+    {
+        $pdo = $this->createSqliteHandler();
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, status TEXT)');
+        $pdo->exec("INSERT INTO users (name, status) VALUES ('alice', 'active')");
+        $pdo->exec("INSERT INTO users (name, status) VALUES ('bob', 'active')");
+        $pdo->exec("INSERT INTO users (name, status) VALUES ('charlie', 'disabled')");
+
+        $rows = SQLManager::sqlScript(
+            'SELECT id, name FROM users WHERE status = :status ORDER BY id ASC',
+            ['status' => 'active']
+        );
+
+        $this->assertSame([
+            ['id' => 1, 'name' => 'alice'],
+            ['id' => 2, 'name' => 'bob'],
+        ], $rows);
+    }
+
+    public function testSqlScriptReturnsSingleRowForCustomSelectWithOneResult(): void
+    {
+        $pdo = $this->createSqliteHandler();
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, status TEXT)');
+        $pdo->exec("INSERT INTO users (name, status) VALUES ('alice', 'active')");
+
+        $row = SQLManager::sqlScript(
+            'SELECT id, name FROM users WHERE status = :status',
+            ['status' => 'active']
+        );
+
+        $this->assertSame(['id' => 1, 'name' => 'alice'], $row);
+    }
+
+    public function testSqlScriptReturnsEmptyArrayForCustomSelectWithNoResults(): void
+    {
+        $pdo = $this->createSqliteHandler();
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, status TEXT)');
+
+        $rows = SQLManager::sqlScript(
+            'SELECT id, name FROM users WHERE status = :status',
+            ['status' => 'active']
+        );
+
+        $this->assertSame([], $rows);
+    }
+
+    public function testSqlScriptReturnsTrueForCustomWriteStatement(): void
+    {
+        $pdo = $this->createSqliteHandler();
+        $pdo->exec('CREATE TABLE users (id INTEGER PRIMARY KEY, name TEXT, status TEXT)');
+        $pdo->exec("INSERT INTO users (name, status) VALUES ('alice', 'active')");
+
+        $result = SQLManager::sqlScript(
+            'UPDATE users SET status = :status WHERE name = :name',
+            ['status' => 'disabled', 'name' => 'alice']
+        );
+
+        $this->assertTrue($result);
+        $this->assertSame(
+            [['status' => 'disabled']],
+            SQLManager::findWhere(['status'], 'users', ['name' => 'alice'])
+        );
+    }
+
     public function testBuildColumnListSupportsQualifiedWildcard(): void
     {
         $method = new \ReflectionMethod(SQLManager::class, 'buildColumnList');

--- a/CorianderCore/core/Database/SQLManager.php
+++ b/CorianderCore/core/Database/SQLManager.php
@@ -312,24 +312,41 @@ class SQLManager
     }
 
     /**
-     * Executes a given SQL query and retrieves a row of data from the database table.
+     * Executes a custom SQL statement with bound parameters.
      *
-     * @param string $sqlScript The SQL query to execute.
-     * @param array  $params    Named parameters to bind to the SQL query (optional).
+     * SELECT-like statements return one associative row when one row is found,
+     * all rows when multiple rows are found, and an empty array when no rows are found.
+     * Write statements return true when execution succeeds.
      *
-     * @return array The retrieved row data as an associative array.
+     * @param string $sqlScript The SQL statement to execute.
+     * @param array  $params    Named parameters to bind to the SQL statement (optional).
+     *
+     * @return array|bool Result rows for SELECT-like statements, or true for write statements.
      *
      * @throws DatabaseException If the query fails.
      */
-    public static function sqlScript(string $sqlScript, array $params = []): array
+    public static function sqlScript(string $sqlScript, array $params = []): array|bool
     {
         try {
             $pdo = self::requirePdo();
             $stmt = $pdo->prepare($sqlScript);
             $stmt->execute($params);
-            $data = $stmt->fetch(PDO::FETCH_ASSOC);
 
-            return $data !== false ? $data : [];
+            if ($stmt->columnCount() === 0) {
+                return true;
+            }
+
+            $data = $stmt->fetchAll(PDO::FETCH_ASSOC);
+
+            if ($data === false || $data === []) {
+                return [];
+            }
+
+            if (count($data) === 1) {
+                return $data[0];
+            }
+
+            return $data;
         } catch (Exception $e) {
             self::getLogger()->error('[SQLManager] sqlScript exception', ['exception' => $e]);
             throw new DatabaseException('Unable to execute SQL script.', 0, $e);

--- a/docs/database.md
+++ b/docs/database.md
@@ -107,7 +107,8 @@ try {
 
 - Use prepared statements and parameter binding to prevent SQL injection.
 - Prefer `findWhere`, `updateWhere`, and `deleteWhere` when your conditions are simple equality checks.
-- `findBy`, `update`, and `deleteFrom` remain available for advanced SQL conditions but are deprecated for routine use.
+- Use `sqlScript` when a repository needs custom SQL such as joins, aggregates, or multi-table reads.
+- `findBy`, `update`, and `deleteFrom` remain available for compatibility but are deprecated for routine use.
 - Keep long-lived connections to a minimum; enable `DatabaseHandler::setAutoCloseConnection(false)` only when necessary.
 - Centralize complex queries in repository classes to maintain SOLID principles.
 - Close connections explicitly in long-running scripts.
@@ -161,17 +162,61 @@ SQLManager::deleteWhere('users', ['status' => 'inactive']);
 ```
 Removes all users currently flagged as inactive.
 
-## Advanced Conditions
+## Custom SQL
 
-For non-equality expressions (`IN`, range queries, SQL functions), use the lower-level methods with explicit placeholders (deprecated for routine use):
+Use `sqlScript` when a repository needs free SQL for joins, aggregates, reports, or custom filtering that does not fit the table-oriented helpers.
+
+SELECT-like statements return data based on the number of rows found:
+
+- no rows: `[]`
+- one row: one associative array
+- multiple rows: a list of associative arrays
 
 ```php
-SQLManager::findBy(
-    ['id', 'email'],
-    'users',
-    'created_at >= :from AND status IN (:s1, :s2)',
-    ['from' => '2026-01-01', 's1' => 'active', 's2' => 'pending']
+use CorianderCore\Core\Database\SQLManager;
+
+$topics = SQLManager::sqlScript(
+    'SELECT topics.id, topics.title, users.username
+     FROM topics
+     JOIN users ON users.id = topics.user_id
+     WHERE topics.status = :status
+     ORDER BY topics.created_at DESC',
+    ['status' => 'published']
 );
+```
+
+For one row, write the query naturally and use the returned associative array:
+
+```php
+$topic = SQLManager::sqlScript(
+    'SELECT id, title FROM topics WHERE id = :id',
+    ['id' => $topicId]
+);
+```
+
+For a single value, select an alias and read it from the first row:
+
+```php
+$row = SQLManager::sqlScript('SELECT COUNT(*) AS total FROM topics');
+
+$total = (int) ($row['total'] ?? 0);
+```
+
+Write statements return `true` when execution succeeds:
+
+```php
+SQLManager::sqlScript(
+    'UPDATE topics SET locked = :locked WHERE id = :id',
+    ['locked' => 1, 'id' => $topicId]
+);
+```
+
+For simple equality-based CRUD, prefer the table helpers:
+
+```php
+SQLManager::findWhere(['id', 'title'], 'topics', ['status' => 'published']);
+SQLManager::updateWhere('topics', ['locked' => 1], ['id' => $topicId]);
+SQLManager::deleteWhere('topics', ['status' => 'draft']);
 ```
 
 

--- a/readme.md
+++ b/readme.md
@@ -67,6 +67,7 @@ Database note: prefer `findWhere`, `updateWhere`, and `deleteWhere`; raw-string 
 Use `findAll(['col1', 'col2'], $table)` to request specific columns.
 Use `findAll($table)` for all columns.
 `findAll(['*'], $table)` remains supported for compatibility but is not recommended.
+Use `sqlScript($sql, $params)` for custom SQL such as joins, aggregates, and repository-owned queries; SELECT-like statements return `[]`, one associative row, or multiple rows depending on the result size, and write statements return `true` on success.
 
 ## CLI Quick Reference
 


### PR DESCRIPTION
## Summary
- Updates `SQLManager::sqlScript()` to behave as a lightweight free-SQL helper for repositories.
- SELECT-like statements now return data based on result size:
  - no rows: `[]`
  - one row: one associative array
  - multiple rows: a list of associative arrays
- Write statements now return `true` when execution succeeds.
- Updates the database docs and README to explain when to use `sqlScript()` instead of table-oriented helpers.
- Adds SQLManager tests for no-row, single-row, multi-row, and write-statement custom SQL behavior.

## Breaking changes / upgrade notes
- `sqlScript()` previously returned only the first row for SELECT queries.
- It can now return multiple rows when the query matches multiple records.
- Existing one-row queries continue to receive one associative row when exactly one record is found.
- Code that assumed extra matching rows were ignored should add `LIMIT 1` to the SQL when only one row is intended.

## Why
This keeps CorianderPHP lightweight while giving repositories a clear escape hatch for joins, aggregates, reports, and multi-table custom queries without adding a query builder, mode parameter, or multiple new method names.

## Validation
- `vendor\\bin\\phpunit --filter SQLManagerTest --testdox`
- `vendor\\bin\\phpunit --testdox`