### PR TITLE
Remove deprecated test reflection access calls

### DIFF
--- a/CorianderCore/Tests/DatabaseHandlerTest.php
+++ b/CorianderCore/Tests/DatabaseHandlerTest.php
@@ -65,7 +65,6 @@ class DatabaseHandlerTest extends TestCase
     {
         $reflection = new \ReflectionClass($handler);
         $pdoProperty = $reflection->getProperty('pdo');
-        $pdoProperty->setAccessible(true);
         $pdoProperty->setValue($handler, $pdo);
     }
 }

--- a/CorianderCore/Tests/GitHubReleaseServiceTest.php
+++ b/CorianderCore/Tests/GitHubReleaseServiceTest.php
@@ -26,8 +26,6 @@ class GitHubReleaseServiceTest extends TestCase
         ];
 
         $method = new \ReflectionMethod($service, 'extractStatusCode');
-        $method->setAccessible(true);
-
         $statusCode = $method->invoke($service, $headers);
 
         $this->assertSame(200, $statusCode);
@@ -70,8 +68,6 @@ class GitHubReleaseServiceTest extends TestCase
     {
         $service = new GitHubReleaseService('CorianderPHP/CorianderPHP');
         $method = new \ReflectionMethod($service, 'selectRelease');
-        $method->setAccessible(true);
-
         $release = $method->invoke($service, [
             ['tag_name' => 'v0.2.0-beta', 'prerelease' => true],
             ['tag_name' => 'v0.1.9', 'prerelease' => false],
@@ -85,8 +81,6 @@ class GitHubReleaseServiceTest extends TestCase
     {
         $service = new GitHubReleaseService('CorianderPHP/CorianderPHP');
         $method = new \ReflectionMethod($service, 'selectRelease');
-        $method->setAccessible(true);
-
         $release = $method->invoke($service, [
             ['tag_name' => 'v0.2.0-beta', 'prerelease' => true],
             ['tag_name' => 'v0.1.9', 'prerelease' => false],
@@ -99,8 +93,6 @@ class GitHubReleaseServiceTest extends TestCase
     {
         $service = new GitHubReleaseService('CorianderPHP/CorianderPHP');
         $method = new \ReflectionMethod($service, 'selectRelease');
-        $method->setAccessible(true);
-
         $release = $method->invoke($service, [
             ['tag_name' => 'v0.2.0-beta', 'prerelease' => true],
         ], false);

--- a/CorianderCore/Tests/SQLManagerTest.php
+++ b/CorianderCore/Tests/SQLManagerTest.php
@@ -32,8 +32,6 @@ class SQLManagerTest extends TestCase
     public function testBuildWhereFromArrayCreatesUniquePlaceholders(): void
     {
         $method = new \ReflectionMethod(SQLManager::class, 'buildWhereFromArray');
-        $method->setAccessible(true);
-
         [$clause, $params] = $method->invoke(null, ['a-b' => 1, 'a_b' => 2], 'w_');
 
         $this->assertSame('`a-b` = :w_a_b AND `a_b` = :w_a_b_1', $clause);
@@ -161,8 +159,6 @@ class SQLManagerTest extends TestCase
     public function testBuildColumnListSupportsQualifiedWildcard(): void
     {
         $method = new \ReflectionMethod(SQLManager::class, 'buildColumnList');
-        $method->setAccessible(true);
-
         $columnList = $method->invoke(null, ['users.*', 'users.name']);
 
         $this->assertSame('`users`.*, `users`.`name`', $columnList);
@@ -171,8 +167,6 @@ class SQLManagerTest extends TestCase
     public function testQuoteIdentifierRejectsEmptyIdentifier(): void
     {
         $method = new \ReflectionMethod(SQLManager::class, 'quoteIdentifier');
-        $method->setAccessible(true);
-
         $this->expectException(DatabaseException::class);
         $method->invoke(null, '');
     }
@@ -185,7 +179,6 @@ class SQLManagerTest extends TestCase
         $handler = new DatabaseHandler();
         $reflection = new \ReflectionClass($handler);
         $pdoProperty = $reflection->getProperty('pdo');
-        $pdoProperty->setAccessible(true);
         $pdoProperty->setValue($handler, $pdo);
 
         SQLManager::setDatabaseHandler($handler);

--- a/CorianderCore/tests/CommandHandlerTest.php
+++ b/CorianderCore/tests/CommandHandlerTest.php
@@ -91,7 +91,6 @@ class CommandHandlerTest extends TestCase
         });
 
         $commandsProperty = (new \ReflectionClass(CommandHandler::class))->getProperty('commands');
-        $commandsProperty->setAccessible(true);
         $commands = $commandsProperty->getValue($this->commandHandler);
         $commands['returnsCode'] = $mockCommandClass;
         $commandsProperty->setValue($this->commandHandler, $commands);
@@ -126,7 +125,6 @@ class CommandHandlerTest extends TestCase
 
         // Modify the 'commands' property of CommandHandler to include the mock command
         $commandsProperty = (new \ReflectionClass(CommandHandler::class))->getProperty('commands');
-        $commandsProperty->setAccessible(true);
         $commands = $commandsProperty->getValue($this->commandHandler);
         $commands['noExecute'] = $mockCommandClass; // Add the mock command without execute method
         $commandsProperty->setValue($this->commandHandler, $commands);

--- a/CorianderCore/tests/SitemapHandlerTest.php
+++ b/CorianderCore/tests/SitemapHandlerTest.php
@@ -100,7 +100,6 @@ class SitemapHandlerTest extends TestCase
 
         $reflection = new ReflectionClass($sitemapHandler);
         $dynamicPagesProperty = $reflection->getProperty('dynamicPages');
-        $dynamicPagesProperty->setAccessible(true);
         $dynamicPages = $dynamicPagesProperty->getValue($sitemapHandler);
 
         $this->assertCount(1, $dynamicPages, 'Dynamic pages count does not match expected value.');


### PR DESCRIPTION
## Summary
- Removes deprecated `setAccessible()` calls from reflection-based tests.
- Keeps the existing reflection test setup intact while relying on modern PHP reflection behavior.
- Scans for other common deprecated APIs and found no remaining matches for the checked patterns.

## Checked patterns
- `setAccessible`
- `utf8_encode` / `utf8_decode`
- `FILTER_SANITIZE_STRING`
- `strftime` / `gmstrftime`
- `create_function`
- `each(`
- deprecated PHPUnit object attribute assertions

## Validation
- `vendor\\bin\\phpunit CorianderCore\\Tests\\DatabaseHandlerTest.php CorianderCore\\Tests\\GitHubReleaseServiceTest.php CorianderCore\\Tests\\CommandHandlerTest.php CorianderCore\\Tests\\SitemapHandlerTest.php CorianderCore\\Tests\\SQLManagerTest.php --testdox`
- `vendor\\bin\\phpunit --testdox`