### PR TITLE
Fix updater release archive downloads

### DIFF
--- a/CorianderCore/Tests/GitHubReleaseServiceTest.php
+++ b/CorianderCore/Tests/GitHubReleaseServiceTest.php
@@ -100,4 +100,15 @@ class GitHubReleaseServiceTest extends TestCase
         $this->assertSame('v0.2.0-beta', $release['tag_name']);
         $this->assertTrue($release['prerelease_fallback']);
     }
+
+    public function testBuildZipUrlUsesBrowserArchiveUrl(): void
+    {
+        $service = new GitHubReleaseService('CorianderPHP/CorianderPHP');
+        $method = new \ReflectionMethod($service, 'buildZipUrl');
+
+        $this->assertSame(
+            'https://github.com/CorianderPHP/CorianderPHP/archive/refs/tags/v0.2.0.zip',
+            $method->invoke($service, 'v0.2.0')
+        );
+    }
 }

--- a/CorianderCore/core/Console/Services/Updater/GitHubReleaseService.php
+++ b/CorianderCore/core/Console/Services/Updater/GitHubReleaseService.php
@@ -34,7 +34,7 @@ class GitHubReleaseService
 
                 return [
                     'tag' => $tag,
-                    'zip_url' => (string) ($release['zipball_url'] ?? $this->buildZipUrl($tag)),
+                    'zip_url' => $this->buildZipUrl($tag),
                     'prerelease' => (bool) ($release['prerelease'] ?? false),
                     'prerelease_fallback' => (bool) ($release['prerelease_fallback'] ?? false),
                 ];


### PR DESCRIPTION
## Summary
- Stops using GitHub release `zipball_url` API endpoints for updater archive downloads.
- Always builds the browser archive URL from the selected tag instead, e.g. `https://github.com/CorianderPHP/CorianderPHP/archive/refs/tags/v0.2.0.zip`.
- Adds a regression test for the archive URL builder.

## Why
Downloading the GitHub API `zipball_url` with the updater's archive request headers can fail with `HTTP 415 Unsupported Media Type`. Using the browser archive URL avoids the API media-type negotiation issue and still redirects to GitHub's archive download.

## Validation
- `vendor\\bin\\phpunit --filter GitHubReleaseServiceTest --testdox`
- `vendor\\bin\\phpunit --testdox`